### PR TITLE
Fix db-migration premistions issue

### DIFF
--- a/charts/engine/Chart.yaml
+++ b/charts/engine/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-engine
 type: application
-version: 1.0.28
+version: 1.0.29

--- a/charts/engine/values.yaml
+++ b/charts/engine/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-939dd57c-stable
+image_tag: master-5f53a126-stable
 
 localDataDirectory: ""
 gpu: false

--- a/charts/node-server/Chart.yaml
+++ b/charts/node-server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-node-server
 type: application
-version: 1.0.27
+version: 1.0.28

--- a/charts/node-server/templates/deployment.yaml
+++ b/charts/node-server/templates/deployment.yaml
@@ -130,6 +130,4 @@ spec:
         - name: shared
           emptyDir: {}
         - name: backups
-          hostPath:
-            path: /mongodb-backups
-            type: DirectoryOrCreate
+          emptyDir: {}

--- a/charts/node-server/values.yaml
+++ b/charts/node-server/values.yaml
@@ -1,1 +1,1 @@
-image_tag: master-0c5c9384-stable
+image_tag: master-b0f25f9d-stable

--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.0.41
+version: 1.0.42
 dependencies:
   - name: ingress-nginx
     version: 4.1.2

--- a/charts/web-ui/Chart.yaml
+++ b/charts/web-ui/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-web-ui
 type: application
-version: 1.0.32
+version: 1.0.33

--- a/charts/web-ui/values.yaml
+++ b/charts/web-ui/values.yaml
@@ -1,1 +1,1 @@
-image_tag: master-90f1277c-stable
+image_tag: master-3b9b5443-stable

--- a/engine-latest-image
+++ b/engine-latest-image
@@ -1,1 +1,1 @@
-gcr.io/tensorleap/engine:master-939dd57c-stable
+gcr.io/tensorleap/engine:master-5f53a126-stable

--- a/node-server-latest-image
+++ b/node-server-latest-image
@@ -1,1 +1,1 @@
-gcr.io/tensorleap/node-server:master-0c5c9384-stable
+gcr.io/tensorleap/node-server:master-b0f25f9d-stable

--- a/web-ui-latest-image
+++ b/web-ui-latest-image
@@ -1,1 +1,1 @@
-gcr.io/tensorleap/web-ui:master-90f1277c-stable
+gcr.io/tensorleap/web-ui:master-3b9b5443-stable


### PR DESCRIPTION
The container has no access to the critical path; since it is not used today, I recommend using just `emptyDir.`

we can also merge the `volumes`
