### PR TITLE
Migrate RabbitMQ from bitnami

### DIFF
--- a/charts/engine/templates/engine-cm.yaml
+++ b/charts/engine/templates/engine-cm.yaml
@@ -7,8 +7,8 @@ data:
   ELASTIC_HOST: http://elasticsearch-master:9200
   SESSION_BUCKET: session
   RABBIT_HOST: rabbitmq
-  RABBIT_USER: user
-  RABBIT_PASSWORD: 3e3abae2-6325-11ec-90d6-0242ac120003
+  RABBIT_USER: guest
+  RABBIT_PASSWORD: guest
   FEEDBACK_TOPIC: feedback
   SUBSCRIBER_TOPIC: job-control-channel
   STORAGE_PROVIDER: minio

--- a/charts/engine/templates/engine-cm.yaml
+++ b/charts/engine/templates/engine-cm.yaml
@@ -6,7 +6,7 @@ data:
   PY_CONFIG: /app/config/config.yaml
   ELASTIC_HOST: http://elasticsearch-master:9200
   SESSION_BUCKET: session
-  RABBIT_HOST: rabbitmq-headless
+  RABBIT_HOST: rabbitmq
   RABBIT_USER: user
   RABBIT_PASSWORD: 3e3abae2-6325-11ec-90d6-0242ac120003
   FEEDBACK_TOPIC: feedback

--- a/charts/node-server/templates/node-server-env-configmap.yaml
+++ b/charts/node-server/templates/node-server-env-configmap.yaml
@@ -8,7 +8,7 @@ data:
   JOB_TOPIC: pytop-k80
   JOB_TOPIC_AUG: pytop-svcs
   MONGO_URI: mongodb://mongodb/tensorleap?tls=false&ssl=false
-  RABBIT_URI: "amqp://user:3e3abae2-6325-11ec-90d6-0242ac120003@rabbitmq-headless"
+  RABBIT_URI: "amqp://user:3e3abae2-6325-11ec-90d6-0242ac120003@rabbitmq"
   BUCKET_NAME: session
   SUBSCRIBER_TOPIC: feedback
   AUTO_ACTIVATE_USER: "true"

--- a/charts/node-server/templates/node-server-env-configmap.yaml
+++ b/charts/node-server/templates/node-server-env-configmap.yaml
@@ -8,7 +8,7 @@ data:
   JOB_TOPIC: pytop-k80
   JOB_TOPIC_AUG: pytop-svcs
   MONGO_URI: mongodb://mongodb/tensorleap?tls=false&ssl=false
-  RABBIT_URI: "amqp://user:3e3abae2-6325-11ec-90d6-0242ac120003@rabbitmq"
+  RABBIT_URI: "amqp://guest:guest@rabbitmq"
   BUCKET_NAME: session
   SUBSCRIBER_TOPIC: feedback
   AUTO_ACTIVATE_USER: "true"

--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -9,9 +9,6 @@ dependencies:
   - name: kibana
     version: 7.6.1 # consider upgrading
     repository: https://helm.elastic.co
-  - name: rabbitmq
-    version: 9.1.3
-    repository: https://charts.bitnami.com/bitnami
   - name: minio
     version: 3.4.3
     repository: https://charts.min.io

--- a/charts/tensorleap/templates/rabbitmq-cm.yaml
+++ b/charts/tensorleap/templates/rabbitmq-cm.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-config
+data:
+  enabled_plugins: |
+    [rabbitmq_management].
+  rabbitmq.conf: |
+    # Auth
+    loopback_users = none
+    # Logs
+    log.file.level = debug
+    log.console = true
+    log.console.level = debug
+  erlangCookie: 3e3abae2-6325-11ec-90d6-0242ac120003

--- a/charts/tensorleap/templates/rabbitmq-sts.yaml
+++ b/charts/tensorleap/templates/rabbitmq-sts.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+  labels:
+    app: rabbitmq
+spec:
+  serviceName: rabbitmq
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3.9.22
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - rabbitmqctl
+                  - stop_app
+          env:
+            - name: RABBITMQ_ERL_COOKIE
+              valueFrom:
+                configMapKeyRef:
+                  name: rabbitmq-config
+                  key: erlangCookie
+            - name: RABBITMQ_DATA_DIR
+              value: /var/lib/rabbitmq
+            - name: RABBITMQ_MNESIA_BASE
+              value: /var/lib/rabbitmq/mnesia
+            - name: RABBITMQ_LOG_BASE
+              value: /var/log/rabbitmq
+          ports:
+            - name: amqp
+              containerPort: 5672
+            - name: http
+              containerPort: 15672
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 20
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - status
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 20
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - ping
+          volumeMounts:
+            - name: rabbitmq-config
+              mountPath: /etc/rabbitmq
+            - name: rabbitmq-data
+              mountPath: /var/lib/rabbitmq
+      volumes:
+        - name: rabbitmq-config
+          configMap:
+            name: rabbitmq-config
+            items:
+              - key: enabled_plugins
+                path: enabled_plugins
+              - key: rabbitmq.conf
+                path: rabbitmq.conf
+  volumeClaimTemplates:
+    - metadata:
+        name: rabbitmq-data
+        labels:
+          app: rabbitmq
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi

--- a/charts/tensorleap/templates/rabbitmq-svc.yaml
+++ b/charts/tensorleap/templates/rabbitmq-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  labels:
+    app: rabbitmq
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: amqp
+    - name: http
+      port: 15672
+      targetPort: http
+  selector:
+    app: rabbitmq

--- a/charts/tensorleap/values.yaml
+++ b/charts/tensorleap/values.yaml
@@ -13,15 +13,6 @@ kibana:
         rewriteBasePath: true
   elasticsearchHosts: http://elasticsearch-master:9200
 
-rabbitmq:
-  fullnameOverride: rabbitmq
-  auth:
-    user: user
-    password: 3e3abae2-6325-11ec-90d6-0242ac120003
-    erlangCookie: 3e3abae2-6325-11ec-90d6-0242ac120003
-  persistence:
-    size: 500Mi
-
 minio:
   mode: standalone
   existingSecret: minio-secret


### PR DESCRIPTION
- Remove rabbitmq bitnami chart
- Add custom rabbitmq chart templates
- Remove old rabbitmq headless refs
- Change to use default rabbitmq user
