### PR TITLE
Fix broken installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ done
 8. Create a cluster with tensorleap installed:
 
 ```bash
-k3d cluster create --config /var/lib/tensorleap/standalone/manifests/k3d-config.yaml
+k3d cluster create --config /var/lib/tensorleap/standalone/manifests/k3d-config.yaml -p "4589:80@loadbalancer"
 ```
 
 note that it will take some time for the installation to be ready. \

--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -6,10 +6,6 @@ volumes:
   - volume: /var/lib/tensorleap/standalone:/var/lib/tensorleap/standalone
   - volume: /var/lib/tensorleap/standalone/scripts/k3d-entrypoint.sh:/bin/k3d-entrypoint.sh
   - volume: /var/lib/tensorleap/standalone/manifests/tensorleap.yaml:/var/lib/rancher/k3s/server/manifests/tensorleap.yaml
-ports:
-  - port: 4589:80
-    nodeFilters:
-      - loadbalancer
 registries:
   use:
     - tensorleap-registry

--- a/install.sh
+++ b/install.sh
@@ -13,10 +13,8 @@ REGISTRY_PORT=${TENSORLEAP_REGISTRY_PORT:=5699}
 
 function setup_http_utils() {
   if type curl > /dev/null; then
-    echo using curl
     HTTP_GET='curl -s --fail'
   elif type wget > /dev/null; then
-    echo using wget
     HTTP_GET='wget -q -O-'
   else
     echo you must have either curl or wget installed.


### PR DESCRIPTION
Apparently specifying the default port in the config file broke the installation because we're specifying the port (to allow overriding it) and it is appending instead of overriding