### PR TITLE
Remove warnings from install script

### DIFF
--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -4,8 +4,14 @@ metadata:
   name: tensorleap
 volumes:
   - volume: /var/lib/tensorleap/standalone:/var/lib/tensorleap/standalone
+    nodeFilters:
+      - server:*
   - volume: /var/lib/tensorleap/standalone/scripts/k3d-entrypoint.sh:/bin/k3d-entrypoint.sh
+    nodeFilters:
+      - server:*
   - volume: /var/lib/tensorleap/standalone/manifests/tensorleap.yaml:/var/lib/rancher/k3s/server/manifests/tensorleap.yaml
+    nodeFilters:
+      - server:*
 registries:
   use:
     - tensorleap-registry

--- a/install.sh
+++ b/install.sh
@@ -299,7 +299,8 @@ function create_tensorleap_cluster() {
   echo Creating tensorleap k3d cluster...
   report_status "{\"type\":\"install-script-creating-cluster\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\",\"volume\":\"$VOLUME\"}"
   $K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml \
-    -p "$PORT:80@loadbalancer" $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM
+    -p "$PORT:80@loadbalancer" $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM \
+    2>&1 | grep -v 'ERRO.*/bin/k3d-entrypoint\.sh' # This hides the expected warning about k3d-entrypoint replacement
 }
 
 function wait_for_cluster_init() {

--- a/install.sh
+++ b/install.sh
@@ -223,7 +223,7 @@ function get_installation_options() {
     VOLUME_ENGINE_VALUES="localDataDirectory: ${VOLUME/*:/}"
   fi
 
-  VOLUMES_MOUNT_PARAM=$([ -z $VOLUME ] && echo '' || echo "-v $VOLUME")
+  VOLUMES_MOUNT_PARAM=$([ -z $VOLUME ] && echo '' || echo "-v $VOLUME@server:*")
 
   USE_GPU=${USE_GPU:=}
   GPU_CLUSTER_PARAMS=""


### PR DESCRIPTION
Adding `server:*` in the `k3d` config file and in the `k3d cluster create` solved this warnings we've been seeing:
```
WARN[0000] No node filter specified
WARN[0000] No node filter specified
WARN[0000] No node filter specified
WARN[0000] No node filter specified
```

And adding `2>&1 | grep -v 'ERRO.*/bin/k3d-entrypoint\.sh'` to the create command hides this ugly warning:
```
ERRO[0003] Node k3d-tensorleap-server-0: Failed executing preStartAction 'WriteFileAction': [WriteFileAction] Writing 451 bytes to /bin/k3d-entrypoint.sh (mode -rwxr--r--): Write custom k3d entrypoint script (that powers the magic fixes): Failed to copy content to container '153bcbdc7f80259f5d07daaf9e197f2b9acf01829b2035879960edc47364e131': Error response from daemon: Error processing tar file(exit status 1): unlinkat /bin/k3d-entrypoint.sh: device or resource busy
```