### PR TITLE
Add retries to download file function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,9 +30,9 @@ function setup_http_utils() {
 
 function download_file() {
   if type curl > /dev/null; then
-    curl -sL --fail $1 -o $2
+    $HTTP_GET $1 '-o' $2
   elif type wget > /dev/null; then
-    wget -q -O $2 $1
+    $HTTP_GET '-O' $2 $1
   else
     echo you must have either curl or wget installed.
     exit -1


### PR DESCRIPTION
This pr makes `download_file` function use the retries mechanism as well over `curl/wget` commands

Tested by the script below (change `VAR_DIR` path if you want to run too) plus local installation

```bash
#!/bin/bash

set -euo pipefail

RETRIES=5
REQUEST_TIMEOUT=10
RETRY_DELAY=0
HTTP_GET="curl -sL --fail --max-time $REQUEST_TIMEOUT --retry $RETRIES --retry-delay $RETRY_DELAY"
WGET="wget -q -O- --timeout=$REQUEST_TIMEOUT --tries=$RETRIES --wait=$RETRY_DELAY"

VAR_DIR='/Users/asafyehezkel/Desktop/installation'

function download_file_curl() {
  echo 'Downloading file using curl'
  $HTTP_GET $1 '-o' $2
  echo 'Downloaded file using curl'
}

function download_file_wget() {
  echo 'Downloading file using wget'
  $WGET '-O' $2 $1
  echo 'Downloaded file using wget'
}


echo 'Downloading config files by wget...'
download_file_wget https://raw.githubusercontent.com/tensorleap/helm-charts/master/config/k3d-config.yaml $VAR_DIR/k3d-config.yaml

echo 'Downloading config files by curl...'
download_file_curl https://raw.githubusercontent.com/tensorleap/helm-charts/master/config/k3d-entrypoint.sh $VAR_DIR/k3d-entrypoint.sh
```