### PR TITLE
Add docker version check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -110,6 +110,17 @@ function check_docker() {
     DOCKER='sudo docker'
     K3D='sudo k3d'
   fi
+
+  REQUIRED_DOCKER_MAJOR_VERSION=20
+  DOCKER_VERSION=$($DOCKER version | sed -ne '/Client:/,/^$/ p' | grep '^ Version:' | xargs | cut -d ' ' -f 2)
+  DOCKER_MAJOR_VERSION=$(echo $DOCKER_VERSION | cut -d '.' -f 1)
+
+  if [ $DOCKER_MAJOR_VERSION -lt $REQUIRED_DOCKER_MAJOR_VERSION ];
+  then
+    report_status "{\"type\":\"install-script-old-docker-version\",\"installId\":\"$INSTALL_ID\",\"dockerVersion\":\"$DOCKER_VERSION\"}"
+    echo "Tensorleap standalone installation requires docker version $REQUIRED_DOCKER_MAJOR_VERSION or above. Installed version: $DOCKER_VERSION"
+      exit -1
+  fi
 }
 
 function get_latest_chart_version() {


### PR DESCRIPTION
Explenation of how to get docker version
```
  docker version             - Prints version information
  sed -ne '/Client:/,/^$/ p' - Remove Server version info
  grep '^ Version:'          - Takes only the Version line
  xargs                      - Merges spaces
  cut -d ' ' -f 2            - Split by <space> and take only the version
  cut -d '.' -f 1            - Split by '.' take only the major version part
```