### PR TITLE
Forward proxy related environment variables to cluster

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,8 @@ REGISTRY_PORT=${TENSORLEAP_REGISTRY_PORT:=5699}
 USE_GPU=${USE_GPU:=}
 GPU_IMAGE='us-central1-docker.pkg.dev/tensorleap/main/k3s:v1.23.8-k3s1-cuda'
 
+FORWARDED_ENVIRONMENT_VARIABLES='all_proxy\|ALL_PROXY\|http_proxy\|HTTP_PROXY\|https_proxy\|HTTPS_PROXY\|no_proxy\|NO_PROXY'
+
 RETRIES=5
 REQUEST_TIMEOUT=5
 RETRY_DELAY=0
@@ -274,6 +276,8 @@ function get_installation_options() {
 EOF
 )
   fi
+
+  CLUSTER_ENV_VARS=$(env | grep "$FORWARDED_ENVIRONMENT_VARIABLES" | sed 's/^/-e /;s/$/@server:*/' | tr '\n' ' ')
 }
 
 function init_var_dir() {
@@ -314,7 +318,7 @@ function create_tensorleap_cluster() {
   echo Creating tensorleap k3d cluster...
   report_status "{\"type\":\"install-script-creating-cluster\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\",\"volume\":\"$VOLUME\"}"
   $K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml \
-    -p "$PORT:80@loadbalancer" $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM \
+    -p "$PORT:80@loadbalancer" $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM $CLUSTER_ENV_VARS \
     2>&1 | grep -v 'ERRO.*/bin/k3d-entrypoint\.sh' # This hides the expected warning about k3d-entrypoint replacement
 }
 


### PR DESCRIPTION
`k3s` appreantly does look at those environment variables as well as forwarding them to the `helm-install-job` as seen [here](https://github.com/k3s-io/helm-controller/blob/f138dd0e5849e4a3398fa0fb557f6a1b3eea78ee/pkg/controllers/chart/chart.go#L624)

Tested and working!

```
# run tinyproxy http://tinyproxy.github.io/
$ DISABLE_REPORTING=true HTTP_PROXY=127.0.0.1:8888 HTTPS_PROXY=127.0.0.1:8888 bash ./install.sh
#... waiting

$ k get jobs/helm-install-tensorleap -ojson | jq '.spec.template.spec.containers[0].env[] | select(.name == "HTTP_PROXY")'
{
  "name": "HTTP_PROXY",
  "value": "127.0.0.1:8888"
}

$ k get jobs/helm-install-tensorleap -ojson | jq '.spec.template.spec.containers[0].env[] | select(.name == "HTTPS_PROXY")'
{
  "name": "HTTPS_PROXY",
  "value": "127.0.0.1:8888"
}
```