### PR TITLE
Allow node-server to update secrets

### DIFF
--- a/charts/engine/Chart.yaml
+++ b/charts/engine/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-engine
 type: application
-version: 1.0.102
+version: 1.0.103

--- a/charts/engine/values.yaml
+++ b/charts/engine/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-dcbccdae-stable
+image_tag: master-1091f093-stable
 
 localDataDirectory: ""
 gpu: false

--- a/charts/node-server/Chart.yaml
+++ b/charts/node-server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-node-server
 type: application
-version: 1.0.105
+version: 1.0.106

--- a/charts/node-server/templates/role.yaml
+++ b/charts/node-server/templates/role.yaml
@@ -19,6 +19,7 @@ rules:
     verbs:
       - create
       - delete
+      - update
   - apiGroups:
       - ''
     resources:

--- a/charts/node-server/values.yaml
+++ b/charts/node-server/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-6b1c8b55-stable
+image_tag: master-a19cf7f2-stable
 
 ingress:
   enabled: true

--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.0.146
+version: 1.0.147
 dependencies:
   - name: ingress-nginx
     version: 4.1.2

--- a/charts/web-ui/Chart.yaml
+++ b/charts/web-ui/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-web-ui
 type: application
-version: 1.0.120
+version: 1.0.121

--- a/charts/web-ui/values.yaml
+++ b/charts/web-ui/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-15b49ca3-stable
+image_tag: master-2a6facb9-stable
 
 ingress:
   enabled: true

--- a/engine-latest-image
+++ b/engine-latest-image
@@ -1,1 +1,1 @@
-us-central1-docker.pkg.dev/tensorleap/main/engine:master-dcbccdae-stable
+us-central1-docker.pkg.dev/tensorleap/main/engine:master-1091f093-stable

--- a/images.txt
+++ b/images.txt
@@ -7,6 +7,6 @@ k8s.gcr.io/ingress-nginx/controller:v1.2.0@sha256:d8196e3bc1e72547c5dec66d6556c0
 k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
 quay.io/minio/mc:RELEASE.2021-12-20T23-43-34Z
 quay.io/minio/minio:RELEASE.2021-12-20T22-07-16Z
-us-central1-docker.pkg.dev/tensorleap/main/engine:master-dcbccdae-stable
-us-central1-docker.pkg.dev/tensorleap/main/node-server:master-6b1c8b55-stable
-us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-15b49ca3-stable
+us-central1-docker.pkg.dev/tensorleap/main/engine:master-1091f093-stable
+us-central1-docker.pkg.dev/tensorleap/main/node-server:master-a19cf7f2-stable
+us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-2a6facb9-stable

--- a/node-server-latest-image
+++ b/node-server-latest-image
@@ -1,1 +1,1 @@
-us-central1-docker.pkg.dev/tensorleap/main/node-server:master-6b1c8b55-stable
+us-central1-docker.pkg.dev/tensorleap/main/node-server:master-a19cf7f2-stable

--- a/web-ui-latest-image
+++ b/web-ui-latest-image
@@ -1,1 +1,1 @@
-us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-15b49ca3-stable
+us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-2a6facb9-stable


### PR DESCRIPTION
This is required for https://github.com/tensorleap/node-server/pull/829
After it's merged, run `update_images` workflow before merging