### PR TITLE
Support setting target namespace for engine jobs

### DIFF
--- a/charts/engine/Chart.yaml
+++ b/charts/engine/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-engine
 type: application
-version: 1.0.106
+version: 1.0.107

--- a/charts/engine/templates/engine-cm.yaml
+++ b/charts/engine/templates/engine-cm.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: engine-cm
+{{ if .Values.global.target_namespace }}
+  namespace: {{ .Values.global.target_namespace }}
+{{ end }}
 data:
   PY_CONFIG: /app/config/config.yaml
   ELASTIC_HOST: http://elasticsearch-master.{{ .Release.Namespace }}.svc:9200

--- a/charts/engine/templates/engine-cm.yaml
+++ b/charts/engine/templates/engine-cm.yaml
@@ -4,14 +4,14 @@ metadata:
   name: engine-cm
 data:
   PY_CONFIG: /app/config/config.yaml
-  ELASTIC_HOST: http://elasticsearch-master:9200
+  ELASTIC_HOST: http://elasticsearch-master.{{ .Release.Namespace }}.svc:9200
   SESSION_BUCKET: session
-  RABBIT_HOST: rabbitmq
+  RABBIT_HOST: rabbitmq.{{ .Release.Namespace }}.svc
   RABBIT_USER: guest
   RABBIT_PASSWORD: guest
   FEEDBACK_TOPIC: feedback
   SUBSCRIBER_TOPIC: job-control-channel
   STORAGE_PROVIDER: minio
-  STORAGE_ENDPOINT: tensorleap-minio
+  STORAGE_ENDPOINT: tensorleap-minio.{{ .Release.Namespace }}.svc
   STORAGE_PORT: "9000"
   CONTENT_BASE_URL: /session/

--- a/charts/engine/values.yaml
+++ b/charts/engine/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-ac7118df-stable
+image_tag: master-66bdd6bb-stable
 
 localDataDirectory: ""
 gpu: false

--- a/charts/node-server/Chart.yaml
+++ b/charts/node-server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-node-server
 type: application
-version: 1.0.108
+version: 1.0.109

--- a/charts/node-server/templates/node-server-env-configmap.yaml
+++ b/charts/node-server/templates/node-server-env-configmap.yaml
@@ -32,3 +32,6 @@ data:
     CHKIakAHnM/Pe7WIBxixK7TG8qRgrOzzBOu2QVt04DVhVcxqZkpglgce+6LZhYmZ
     fUdjVwvr9Nq+s5Fc1QN4uQkCAwEAAQ==
     -----END PUBLIC KEY-----
+{{ if .Values.global.target_namespace }}
+  TARGET_NAMESPACE: {{ .Values.global.target_namespace }}
+{{ end }}

--- a/charts/node-server/templates/role-binding.yaml
+++ b/charts/node-server/templates/role-binding.yaml
@@ -4,9 +4,25 @@ metadata:
   name: node-server-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: {{ empty .Values.global.target_namespace | ternary "Role" "ClusterRole" }}
   name: node-server-role
 subjects:
   - kind: ServiceAccount
     name: node-server-sa
     namespace: {{ .Release.Namespace }}
+---
+{{ if .Values.global.target_namespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: node-server-role-binding
+  namespace: {{ .Values.global.target_namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-server-role
+subjects:
+  - kind: ServiceAccount
+    name: node-server-sa
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/node-server/templates/role.yaml
+++ b/charts/node-server/templates/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: {{ empty .Values.global.target_namespace | ternary "Role" "ClusterRole" }}
 metadata:
   name: node-server-role
 rules:

--- a/charts/node-server/values.yaml
+++ b/charts/node-server/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-974b9d37-stable
+image_tag: master-24c6026a-stable
 
 ingress:
   enabled: true

--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.0.150
+version: 1.0.151
 dependencies:
   - name: ingress-nginx
     version: 4.1.2

--- a/charts/tensorleap/values.yaml
+++ b/charts/tensorleap/values.yaml
@@ -21,3 +21,6 @@ minio:
   buckets:
     - name: session
       policy: public
+
+global:
+  target_namespace: ''

--- a/engine-latest-image
+++ b/engine-latest-image
@@ -1,1 +1,1 @@
-us-central1-docker.pkg.dev/tensorleap/main/engine:master-ac7118df-stable
+us-central1-docker.pkg.dev/tensorleap/main/engine:master-66bdd6bb-stable

--- a/images.txt
+++ b/images.txt
@@ -6,6 +6,6 @@ k8s.gcr.io/ingress-nginx/controller:v1.2.0@sha256:d8196e3bc1e72547c5dec66d6556c0
 k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
 quay.io/minio/mc:RELEASE.2021-12-20T23-43-34Z
 quay.io/minio/minio:RELEASE.2021-12-20T22-07-16Z
-us-central1-docker.pkg.dev/tensorleap/main/engine:master-ac7118df-stable
-us-central1-docker.pkg.dev/tensorleap/main/node-server:master-974b9d37-stable
+us-central1-docker.pkg.dev/tensorleap/main/engine:master-66bdd6bb-stable
+us-central1-docker.pkg.dev/tensorleap/main/node-server:master-24c6026a-stable
 us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-ca9a3c7a-stable

--- a/node-server-latest-image
+++ b/node-server-latest-image
@@ -1,1 +1,1 @@
-us-central1-docker.pkg.dev/tensorleap/main/node-server:master-974b9d37-stable
+us-central1-docker.pkg.dev/tensorleap/main/node-server:master-24c6026a-stable


### PR DESCRIPTION
To try this:
1. Upgrade you standalone installation to latest (using the normal installation script)
2. run `kubectl create ns TARGET_NAMESPACE`
3. run `kubectl delete rolebinding node-server-role-binding -n tensorleap`
4. run `helm upgrade tensorleap ./charts/tensorleap -n tensorleap --reuse-values --set 'global.target_namespace=TARGET_NAMESPACE' --wait`