### PR TITLE
Customize installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ done
 8. Create a cluster with tensorleap installed:
 
 ```bash
-k3d cluster create --config /var/lib/tensorleap/standalone/manifests/k3d-config.yaml -p "4589:80@loadbalancer"
+k3d cluster create --config /var/lib/tensorleap/standalone/manifests/k3d-config.yaml
 ```
 
 note that it will take some time for the installation to be ready. \

--- a/README.md
+++ b/README.md
@@ -126,11 +126,5 @@ k3d cluster create --config /var/lib/tensorleap/standalone/manifests/k3d-config.
 note that it will take some time for the installation to be ready. \
 You can monitor progress by inspecting the cluster with `kubectl`
 
-9. Create a directory inside the container for db backups
-
-```
-docker exec -it k3d-tensorleap-server-0 mkdir -m 777 /mongodb-backups
-```
-
-10. After the self initialization of the cluster, Tensorleap should be available on http://127.0.0.1:4589
+9. After the self initialization of the cluster, Tensorleap should be available on http://127.0.0.1:4589
 </details>

--- a/charts/node-server/Chart.yaml
+++ b/charts/node-server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-node-server
 type: application
-version: 1.0.117
+version: 1.0.118

--- a/charts/node-server/templates/deployment.yaml
+++ b/charts/node-server/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
 
               echo "Locking DB"
               FAILED_TO_GET_LOCK=$(mongosh $MONGO_URI --eval "db.db_metadata.findOneAndUpdate({_id: 1, schemaVersion: $CURRNET_VERSION, lock: { \$exists: false }}, { \$set: { lock: 'Preparing for migration from $CURRNET_VERSION to $LATEST_VERSION' }})" --quiet)
-              if [ $FAILED_TO_GET_LOCK == 'true' ]
+              if [ "$FAILED_TO_GET_LOCK" == 'true' ];
               then
                 echo "Failed to lock DB! (Could be failed migration), waiting for lock to clear before restarting"
                 LOCK_TEXT=$(mongosh $MONGO_URI --eval "db.db_metadata.findOne({ _id: 1 }).lock" --quiet)

--- a/charts/node-server/templates/deployment.yaml
+++ b/charts/node-server/templates/deployment.yaml
@@ -53,10 +53,10 @@ spec:
               fi
 
               echo "Locking DB"
-              FAILED_TO_GET_LOCK=$(mongosh $MONGO_URI --eval "db.db_metadata.findOneAndUpdate({_id: 1, schemaVersion: $CURRNET_VERSION, lock: { \$exists: false }}, { \$set: { lock: 'Backup before migration from $CURRNET_VERSION to $LATEST_VERSION' }})" --quiet)
+              FAILED_TO_GET_LOCK=$(mongosh $MONGO_URI --eval "db.db_metadata.findOneAndUpdate({_id: 1, schemaVersion: $CURRNET_VERSION, lock: { \$exists: false }}, { \$set: { lock: 'Preparing for migration from $CURRNET_VERSION to $LATEST_VERSION' }})" --quiet)
               if [ $FAILED_TO_GET_LOCK == 'true' ]
               then
-                echo "Failed to lock DB! (Could be failed migration or backup), waiting for lock to clear before restarting"
+                echo "Failed to lock DB! (Could be failed migration), waiting for lock to clear before restarting"
                 LOCK_TEXT=$(mongosh $MONGO_URI --eval "db.db_metadata.findOne({ _id: 1 }).lock" --quiet)
                 until [ -z "$LOCK_TEXT" ]
                 do
@@ -70,10 +70,6 @@ spec:
                 exit -1
               fi
 
-              TIMESTAMP=$(date +%s)
-              BACKUP_FILE_NAME="tensorleap-backup-$CURRNET_VERSION-before-$LATEST_VERSION-$TIMESTAMP.tgz"
-              echo "Backing up database to $BACKUP_FILE_NAME"
-              mongodump --archive=/mnt/backups/$BACKUP_FILE_NAME --db=tensorleap $MONGO_URI
               for file in $(ls *.js | sort); do
                 VERSION=$(echo $file | sed 's/-.*$//' | sed 's/^0*//')
                 if [ $VERSION -gt $CURRNET_VERSION ]
@@ -92,8 +88,6 @@ spec:
           volumeMounts:
             - mountPath: /mnt/shared
               name: shared
-            - mountPath: /mnt/backups
-              name: backups
           envFrom:
             - configMapRef:
                 name: tensorleap-node-server-env-configmap
@@ -153,7 +147,3 @@ spec:
       volumes:
         - name: shared
           emptyDir: {}
-        - name: backups
-          hostPath:
-            path: /mongodb-backups
-            type: DirectoryOrCreate

--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.0.161
+version: 1.0.162
 dependencies:
   - name: ingress-nginx
     version: 4.1.2

--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -12,6 +12,10 @@ volumes:
   - volume: /var/lib/tensorleap/standalone/manifests/tensorleap.yaml:/var/lib/rancher/k3s/server/manifests/tensorleap.yaml
     nodeFilters:
       - server:*
+ports:
+  - port: 4589:80
+    nodeFilters:
+      - loadbalancer
 registries:
   use:
     - tensorleap-registry

--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -29,9 +29,6 @@ registries:
       docker.elastic.co:
         endpoint:
           - http://k3d-tensorleap-registry:5000
-      k3s.gcr.io:
-        endpoint:
-          - http://k3d-tensorleap-registry:5000
       quay.io:
         endpoint:
           - http://k3d-tensorleap-registry:5000

--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -16,6 +16,31 @@ ports:
   - port: 4589:80
     nodeFilters:
       - loadbalancer
+env:
+  - envVar: all_proxy=${all_proxy}
+    nodeFilters:
+      - server:*
+  - envVar: ALL_PROXY=${ALL_PROXY}
+    nodeFilters:
+      - server:*
+  - envVar: http_proxy=${http_proxy}
+    nodeFilters:
+      - server:*
+  - envVar: HTTP_PROXY=${HTTP_PROXY}
+    nodeFilters:
+      - server:*
+  - envVar: https_proxy=${https_proxy}
+    nodeFilters:
+      - server:*
+  - envVar: HTTPS_PROXY=${HTTPS_PROXY}
+    nodeFilters:
+      - server:*
+  - envVar: no_proxy=${no_proxy}
+    nodeFilters:
+      - server:*
+  - envVar: NO_PROXY=${NO_PROXY}
+    nodeFilters:
+      - server:*
 registries:
   use:
     - tensorleap-registry

--- a/install.sh
+++ b/install.sh
@@ -242,7 +242,6 @@ function cache_images_in_registry() {
 }
 
 function get_installation_options() {
-  # Get port and volume mount
   DEFAULT_VOLUME="$HOME/tensorleap/data"
   VOLUME=${DATA_VOLUME:=$DEFAULT_VOLUME:$DEFAULT_VOLUME}
   LOCAL_PATH=${VOLUME/:*/}

--- a/install.sh
+++ b/install.sh
@@ -248,7 +248,6 @@ function cache_images_in_registry() {
 
 function get_installation_options() {
   # Get port and volume mount
-  PORT=${TENSORLEAP_PORT:=4589}
   DEFAULT_VOLUME="$HOME/tensorleap/data"
   VOLUME=${DATA_VOLUME:=$DEFAULT_VOLUME:$DEFAULT_VOLUME}
   LOCAL_PATH=${VOLUME/:*/}
@@ -345,8 +344,7 @@ EOF
 function create_tensorleap_cluster() {
   echo Creating tensorleap k3d cluster...
   report_status "{\"type\":\"install-script-creating-cluster\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\",\"volume\":\"$VOLUME\"}"
-  $K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml \
-    -p "$PORT:80@loadbalancer" $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM $CLUSTER_ENV_VARS \
+  $K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM $CLUSTER_ENV_VARS \
     2>&1 | grep -v 'ERRO.*/bin/k3d-entrypoint\.sh' # This hides the expected warning about k3d-entrypoint replacement
 }
 
@@ -371,7 +369,7 @@ function wait_for_cluster_init() {
     if !(run_in_docker kubectl wait --for=condition=complete --timeout=25m -n kube-system job helm-install-tensorleap);
     then
       report_status "{\"type\":\"install-script-helm-install-timeout\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\"}"
-      echo "Timeout! Cluster is starting in the background, wait a few minutes and see if Tensorleap is available on http://127.0.0.1:$PORT If it's not, contact support"
+      echo "Timeout! Cluster is starting in the background, wait a few minutes and see if Tensorleap is available on http://127.0.0.1:4589 If it's not, contact support"
       exit -1
     fi
   fi
@@ -380,7 +378,7 @@ function wait_for_cluster_init() {
   if !(run_in_docker kubectl wait --for=condition=available --timeout=25m -n tensorleap deploy -l app.kubernetes.io/managed-by=Helm);
   then
     report_status "{\"type\":\"install-script-deployment-timeout\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\"}"
-    echo "Timeout! Cluster is starting in the background, wait a few minutes and see if Tensorleap is available on http://127.0.0.1:$PORT If it's not, contact support"
+    echo "Timeout! Cluster is starting in the background, wait a few minutes and see if Tensorleap is available on http://127.0.0.1:4589 If it's not, contact support"
     exit -1
   fi
 }
@@ -416,7 +414,7 @@ function install_new_tensorleap_cluster() {
   wait_for_cluster_init
 
   report_status "{\"type\":\"install-script-install-success\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\"}"
-  echo "Tensorleap demo installed! It should be available now on http://127.0.0.1:$PORT"
+  echo "Tensorleap demo installed! It should be available now on http://127.0.0.1:4589"
 }
 
 function update_existing_chart() {

--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,6 @@ USE_LOCAL_HELM=${USE_LOCAL_HELM:=}
 USE_GPU=${USE_GPU:=}
 GPU_IMAGE='us-central1-docker.pkg.dev/tensorleap/main/k3s:v1.23.8-k3s1-cuda'
 
-FORWARDED_ENVIRONMENT_VARIABLES='all_proxy\|ALL_PROXY\|http_proxy\|HTTP_PROXY\|https_proxy\|HTTPS_PROXY\|no_proxy\|NO_PROXY'
-
 RETRIES=5
 REQUEST_TIMEOUT=20
 RETRY_DELAY=0
@@ -280,12 +278,6 @@ EOF
       ${GPU_ENGINE_VALUES}
 EOF
 )
-
-  CLUSTER_ENV_VARS=""
-  if env | grep "$FORWARDED_ENVIRONMENT_VARIABLES" &> /dev/null;
-  then
-    CLUSTER_ENV_VARS=$(env | grep "$FORWARDED_ENVIRONMENT_VARIABLES" | sed 's/^/-e /;s/$/@server:*/' | tr '\n' ' ')
-  fi
 }
 
 function init_var_dir() {
@@ -331,12 +323,12 @@ EOF
 function create_tensorleap_cluster() {
   if [ "$DISABLE_CLUSTER_CREATION" == "true" ]; then
     echo 'To continue installation run:'
-    echo "$K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM $CLUSTER_ENV_VARS"
+    echo "$K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM"
     exit 0;
   fi
   echo Creating tensorleap k3d cluster...
   report_status "{\"type\":\"install-script-creating-cluster\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\",\"volume\":\"$VOLUME\"}"
-  $K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM $CLUSTER_ENV_VARS \
+  $K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM \
     2>&1 | grep -v 'ERRO.*/bin/k3d-entrypoint\.sh' # This hides the expected warning about k3d-entrypoint replacement
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 set -euo pipefail
 
 DISABLE_REPORTING=${DISABLE_REPORTING:=}
+DISABLE_CLUSTER_CREATION=${DISABLE_CLUSTER_CREATION:=}
 
 INSTALL_ID=$RANDOM$RANDOM
 DOCKER=docker
@@ -337,6 +338,11 @@ EOF
 }
 
 function create_tensorleap_cluster() {
+  if [ "$DISABLE_CLUSTER_CREATION" == "true" ]; then
+    echo 'To continue installation run:'
+    echo "$K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM $CLUSTER_ENV_VARS"
+    exit 0;
+  fi
   echo Creating tensorleap k3d cluster...
   report_status "{\"type\":\"install-script-creating-cluster\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\",\"volume\":\"$VOLUME\"}"
   $K3D cluster create --config $VAR_DIR/manifests/k3d-config.yaml $GPU_CLUSTER_PARAMS $VOLUMES_MOUNT_PARAM $CLUSTER_ENV_VARS \

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@ set -euo pipefail
 
 DISABLE_REPORTING=${DISABLE_REPORTING:=}
 DISABLE_CLUSTER_CREATION=${DISABLE_CLUSTER_CREATION:=}
+FILES_BRANCH=${FILES_BRANCH:=master}
 
 INSTALL_ID=$RANDOM$RANDOM
 DOCKER=docker
@@ -145,7 +146,7 @@ function check_helm() {
 
 function get_latest_chart_version() {
   echo Getting latest version...
-  LATEST_CHART_VERSION=$($HTTP_GET https://raw.githubusercontent.com/tensorleap/helm-charts/master/charts/tensorleap/Chart.yaml | grep '^version:' | cut -c 10-)
+  LATEST_CHART_VERSION=$($HTTP_GET https://raw.githubusercontent.com/tensorleap/helm-charts/$FILES_BRANCH/charts/tensorleap/Chart.yaml | grep '^version:' | cut -c 10-)
   echo $LATEST_CHART_VERSION
 }
 
@@ -237,7 +238,7 @@ function cache_images_in_registry() {
     k3s_version=$($K3D version | grep 'k3s version' | sed 's/.*version //;s/ .*//;s/-/+/')
   fi
   cat \
-    <($HTTP_GET https://raw.githubusercontent.com/tensorleap/helm-charts/master/images.txt) \
+    <($HTTP_GET https://raw.githubusercontent.com/tensorleap/helm-charts/$FILES_BRANCH/images.txt) \
     <($HTTP_GET https://github.com/k3s-io/k3s/releases/download/$k3s_version/k3s-images.txt) \
     | xargs -P3 -IXXX bash -c "cache_image $REGISTRY_PORT XXX"
 }
@@ -305,8 +306,8 @@ function init_var_dir() {
   mkdir -p $VAR_DIR/scripts
 
   echo 'Downloading config files...'
-  download_file https://raw.githubusercontent.com/tensorleap/helm-charts/master/config/k3d-config.yaml $VAR_DIR/manifests/k3d-config.yaml
-  download_file https://raw.githubusercontent.com/tensorleap/helm-charts/master/config/k3d-entrypoint.sh $VAR_DIR/scripts/k3d-entrypoint.sh
+  download_file https://raw.githubusercontent.com/tensorleap/helm-charts/$FILES_BRANCH/config/k3d-config.yaml $VAR_DIR/manifests/k3d-config.yaml
+  download_file https://raw.githubusercontent.com/tensorleap/helm-charts/$FILES_BRANCH/config/k3d-entrypoint.sh $VAR_DIR/scripts/k3d-entrypoint.sh
   sudo chmod +x $VAR_DIR/scripts/k3d-entrypoint.sh
 }
 

--- a/install.sh
+++ b/install.sh
@@ -250,13 +250,8 @@ function get_installation_options() {
   LOCAL_PATH=${VOLUME/:*/}
   [ ! -d "$LOCAL_PATH" ] && mkdir -p $LOCAL_PATH
 
-  VOLUME_ENGINE_VALUES=""
-  if [ -n "$VOLUME" ]
-  then
-    VOLUME_ENGINE_VALUES="localDataDirectory: ${VOLUME/*:/}"
-  fi
-
-  VOLUMES_MOUNT_PARAM=$([ -z $VOLUME ] && echo '' || echo "-v $VOLUME@server:*")
+  VOLUME_ENGINE_VALUES="localDataDirectory: ${VOLUME/*:/}"
+  VOLUMES_MOUNT_PARAM="-v $VOLUME@server:*"
 
   if [ "$FIX_DNS" == "true" ]
   then
@@ -271,25 +266,20 @@ function get_installation_options() {
     GPU_ENGINE_VALUES='gpu: true'
   fi
 
-  VALUES_FILE=""
-  VALUES_CONTENT=""
-  if [ -n "$VOLUME_ENGINE_VALUES$GPU_ENGINE_VALUES" ]
-  then
-    VALUES_FILE=$(cat << EOF
+  VALUES_FILE=$(cat << EOF
 tensorleap-engine:
   ${VOLUME_ENGINE_VALUES}
   ${GPU_ENGINE_VALUES}
 EOF
 )
 
-    VALUES_CONTENT=$(cat << EOF
+  VALUES_CONTENT=$(cat << EOF
   valuesContent: |-
     tensorleap-engine:
       ${VOLUME_ENGINE_VALUES}
       ${GPU_ENGINE_VALUES}
 EOF
 )
-  fi
 
   CLUSTER_ENV_VARS=""
   if env | grep "$FORWARDED_ENVIRONMENT_VARIABLES" &> /dev/null;

--- a/install.sh
+++ b/install.sh
@@ -152,10 +152,6 @@ function run_in_docker() {
   $DOCKER exec -it k3d-tensorleap-server-0 $*
 }
 
-function create_docker_backups_folder() {
-  run_in_docker mkdir -m 777 /mongodb-backups &> /dev/null || run_in_docker chmod -R 777 /mongodb-backups
-}
-
 function check_docker_requirements() {
 
   NO_RESOURCES=''
@@ -408,7 +404,6 @@ function install_new_tensorleap_cluster() {
   init_var_dir
   create_tensorleap_helm_manifest
   create_tensorleap_cluster
-  create_docker_backups_folder
   run_helm_install
   wait_for_cluster_init
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,6 @@ K3D=k3d
 HELM=helm
 
 VAR_DIR='/var/lib/tensorleap/standalone'
-K3S_VAR_DIR='/var/lib/rancher/k3s'
 
 REGISTRY_PORT=${TENSORLEAP_REGISTRY_PORT:=5699}
 


### PR DESCRIPTION
This PR makes some refactoring and changes to get ready for the following PR fixing the storage as well as to makes development a bit easier.

Main changes:
1. Obsolete code is removed
2. `DISABLE_CLUSTER_CREATION=true` can not be specified not create the cluster but just get to the final point, ready to call `k3d cluster create` - it also print the complete command that need to be called in that point (that can help a lot with development and debugging, there is not need to run the complete script over and over again)
3. Backups before db migrations are removed
4. `FILES_BRANCH=$(git_current_branch)` can be specified to download the config files from the working branch (assuming it's pushed), this removes the need to do temporary changes to the code in order to test changes in the downloaded files
5. The port-mapping (4589) and proxy environmnet variables are now managed in the static `k3d-config.yaml` files instead of in the installation script