### PR TITLE
Remove cache volume mount

### DIFF
--- a/charts/engine/templates/engine-job-template-gpu-cm.yaml
+++ b/charts/engine/templates/engine-job-template-gpu-cm.yaml
@@ -25,6 +25,10 @@ data:
                 - configMapRef:
                     name: engine-cm
               volumeMounts:
+{{- range .Values.additional_pvcs }}
+                - name: {{ .name  }}-vol
+                  mountPath: {{ .mountPath }}
+{{- end }}
 {{ if .Values.localDataDirectory }}
                 - name: local-user-data
                   mountPath: {{ .Values.localDataDirectory }}
@@ -34,6 +38,11 @@ data:
           schedulerName: {{ .Values.schedulerName }}
 {{ end }}
           volumes:
+{{- range .Values.additional_pvcs }}
+            - name: {{ .name  }}-vol
+              persistentVolumeClaim:
+                claimName: {{ .name }}
+{{- end }}
 {{ if .Values.localDataDirectory }}
             - name: local-user-data
               hostPath:

--- a/charts/engine/templates/engine-job-template-gpu-cm.yaml
+++ b/charts/engine/templates/engine-job-template-gpu-cm.yaml
@@ -25,8 +25,6 @@ data:
                 - configMapRef:
                     name: engine-cm
               volumeMounts:
-                - name: engine-pvc
-                  mountPath: /nfs/
 {{ if .Values.localDataDirectory }}
                 - name: local-user-data
                   mountPath: {{ .Values.localDataDirectory }}
@@ -36,10 +34,6 @@ data:
           schedulerName: {{ .Values.schedulerName }}
 {{ end }}
           volumes:
-            - name: engine-pvc
-              hostPath:
-                path: /engine-data
-                type: DirectoryOrCreate
 {{ if .Values.localDataDirectory }}
             - name: local-user-data
               hostPath:

--- a/charts/engine/templates/engine-job-template-pysvcs-cm.yaml
+++ b/charts/engine/templates/engine-job-template-pysvcs-cm.yaml
@@ -21,8 +21,6 @@ data:
                 - configMapRef:
                     name: engine-cm
               volumeMounts:
-                - name: engine-pvc
-                  mountPath: /nfs/
 {{ if .Values.localDataDirectory }}
                 - name: local-user-data
                   mountPath: {{ .Values.localDataDirectory }}
@@ -32,10 +30,6 @@ data:
           schedulerName: {{ .Values.schedulerName }}
 {{ end }}
           volumes:
-            - name: engine-pvc
-              hostPath:
-                path: /engine-data
-                type: DirectoryOrCreate
 {{ if .Values.localDataDirectory }}
             - name: local-user-data
               hostPath:

--- a/charts/engine/templates/engine-job-template-pysvcs-cm.yaml
+++ b/charts/engine/templates/engine-job-template-pysvcs-cm.yaml
@@ -21,6 +21,10 @@ data:
                 - configMapRef:
                     name: engine-cm
               volumeMounts:
+{{- range .Values.additional_pvcs }}
+                - name: {{ .name  }}-vol
+                  mountPath: {{ .mountPath }}
+{{- end }}
 {{ if .Values.localDataDirectory }}
                 - name: local-user-data
                   mountPath: {{ .Values.localDataDirectory }}
@@ -30,6 +34,11 @@ data:
           schedulerName: {{ .Values.schedulerName }}
 {{ end }}
           volumes:
+{{- range .Values.additional_pvcs }}
+            - name: {{ .name  }}-vol
+              persistentVolumeClaim:
+                claimName: {{ .name }}
+{{- end }}
 {{ if .Values.localDataDirectory }}
             - name: local-user-data
               hostPath:

--- a/charts/engine/values.yaml
+++ b/charts/engine/values.yaml
@@ -2,3 +2,5 @@ image_tag: master-ed130c21-stable
 
 localDataDirectory: ""
 gpu: false
+
+additional_pvcs: []


### PR DESCRIPTION
This removes the local mount to `/nfs` on engine containers
This finalizes https://www.pivotaltracker.com/story/show/183894437 as everything else uses `pvc` except for this