### PR TITLE
Remove minio post update hooks

### DIFF
--- a/charts/engine/Chart.yaml
+++ b/charts/engine/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-engine
 type: application
-version: 1.0.113
+version: 1.0.114

--- a/charts/engine/values.yaml
+++ b/charts/engine/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-ed130c21-stable
+image_tag: master-38250430-stable
 
 localDataDirectory: ""
 gpu: false

--- a/charts/node-server/Chart.yaml
+++ b/charts/node-server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-node-server
 type: application
-version: 1.0.119
+version: 1.0.120

--- a/charts/node-server/templates/node-server-env-configmap.yaml
+++ b/charts/node-server/templates/node-server-env-configmap.yaml
@@ -7,6 +7,7 @@ data:
   MONGO_URI: mongodb://mongodb/tensorleap?tls=false&ssl=false
   RABBIT_URI: "amqp://guest:guest@rabbitmq"
   BUCKET_NAME: session
+  ENSURE_BUCKET_EXISTS: "true"
   SUBSCRIBER_TOPIC: feedback
   AUTO_ACTIVATE_USER: "true"
   INSECURE_COOKIE: "true"

--- a/charts/node-server/values.yaml
+++ b/charts/node-server/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-abdd2d64-stable
+image_tag: master-df1ba0c4-stable
 
 ingress:
   enabled: true

--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.0.164
+version: 1.0.165
 dependencies:
   - name: ingress-nginx
     version: 4.1.2

--- a/charts/tensorleap/values.yaml
+++ b/charts/tensorleap/values.yaml
@@ -18,9 +18,6 @@ minio:
   resources:
     requests:
       memory: 500Mi
-  buckets:
-    - name: session
-      policy: public
 
 global:
   target_namespace: ''

--- a/charts/tensorleap/values.yaml
+++ b/charts/tensorleap/values.yaml
@@ -18,6 +18,7 @@ minio:
   resources:
     requests:
       memory: 500Mi
+  users: []
 
 global:
   target_namespace: ''

--- a/charts/web-ui/Chart.yaml
+++ b/charts/web-ui/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-web-ui
 type: application
-version: 1.0.129
+version: 1.0.130

--- a/charts/web-ui/values.yaml
+++ b/charts/web-ui/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-5235cf92-stable
+image_tag: master-d15427da-stable
 
 ingress:
   enabled: true

--- a/engine-latest-image
+++ b/engine-latest-image
@@ -1,1 +1,1 @@
-us-central1-docker.pkg.dev/tensorleap/main/engine:master-ed130c21-stable
+us-central1-docker.pkg.dev/tensorleap/main/engine:master-38250430-stable

--- a/images.txt
+++ b/images.txt
@@ -4,8 +4,7 @@ docker.io/library/mongo:5.0.11
 docker.io/library/rabbitmq:3.9.22
 k8s.gcr.io/ingress-nginx/controller:v1.2.0@sha256:d8196e3bc1e72547c5dec66d6556c0ff92a23f6d0919b206be170bc90d5f9185
 k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
-quay.io/minio/mc:RELEASE.2021-12-20T23-43-34Z
 quay.io/minio/minio:RELEASE.2021-12-20T22-07-16Z
-us-central1-docker.pkg.dev/tensorleap/main/engine:master-ed130c21-stable
-us-central1-docker.pkg.dev/tensorleap/main/node-server:master-abdd2d64-stable
-us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-5235cf92-stable
+us-central1-docker.pkg.dev/tensorleap/main/engine:master-38250430-stable
+us-central1-docker.pkg.dev/tensorleap/main/node-server:master-df1ba0c4-stable
+us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-d15427da-stable

--- a/node-server-latest-image
+++ b/node-server-latest-image
@@ -1,1 +1,1 @@
-us-central1-docker.pkg.dev/tensorleap/main/node-server:master-abdd2d64-stable
+us-central1-docker.pkg.dev/tensorleap/main/node-server:master-df1ba0c4-stable

--- a/web-ui-latest-image
+++ b/web-ui-latest-image
@@ -1,1 +1,1 @@
-us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-5235cf92-stable
+us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-d15427da-stable


### PR DESCRIPTION
The user that is created by default is redundunt, no one uses it or knows about it.
The bucket creation has been implemented (and tested) with https://github.com/tensorleap/node-server/pull/861

This is preperation for completly removing the `helm` chart dependency.

It also completely removes the image that is used for the hook jobs and it's one thing less to cache! 💪 