### PR TITLE
Remove dependency on minio helm chart

### DIFF
--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,12 +1,9 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.0.165
+version: 1.0.166
 dependencies:
   - name: ingress-nginx
     version: 4.1.2
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
-  - name: minio
-    version: 3.4.3
-    repository: https://charts.min.io

--- a/charts/tensorleap/templates/minio-deployment.yaml
+++ b/charts/tensorleap/templates/minio-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tensorleap-minio
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: tensorleap-minio
+      labels:
+        app: minio
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: minio-sa
+      containers:
+        - name: minio
+          image: "quay.io/minio/minio:RELEASE.2021-12-20T22-07-16Z"
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio server /export -S /etc/minio/certs/ --address :9000 --console-address :9001"
+          volumeMounts:
+            - name: minio-user
+              mountPath: "/tmp/credentials"
+              readOnly: true
+            - name: export
+              mountPath: /export
+          ports:
+            - name: http
+              containerPort: 9000
+            - name: http-console
+              containerPort: 9001
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: rootPassword
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: "public"
+          resources:
+            requests:
+              memory: 500Mi
+      volumes:
+        - name: export
+          persistentVolumeClaim:
+            claimName: tensorleap-minio
+        - name: minio-user
+          secret:
+            secretName: minio-secret

--- a/charts/tensorleap/templates/minio-pvc.yaml
+++ b/charts/tensorleap/templates/minio-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tensorleap-minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  volumeName: minio-data

--- a/charts/tensorleap/templates/minio-sa.yaml
+++ b/charts/tensorleap/templates/minio-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio-sa

--- a/charts/tensorleap/templates/minio-svc.yaml
+++ b/charts/tensorleap/templates/minio-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tensorleap-minio
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      nodePort: 32000
+  selector:
+    app: minio
+    release: tensorleap


### PR DESCRIPTION
This PR is a continuation of #82

Tested locally!
The is the diff between the `helm template` command outputs before and after this commit
```diff
Only in old: configmap-tensorleap-minio.yaml
diff old/deployment-tensorleap-minio.yaml new/deployment-tensorleap-minio.yaml
1c1
< # Source: tensorleap/charts/minio/templates/deployment.yaml
---
> # Source: tensorleap/templates/minio-deployment.yaml
6,11d5
<   namespace: "tensorleap"
<   labels:
<     app: minio
<     chart: minio-3.4.3
<     release: tensorleap
<     heritage: Helm
29,31d22
<       annotations:
<         checksum/secrets: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
<         checksum/config: 7d3c1e66706cb709e3565618b666237c53ee4a3a01b50a9a5f7c4122771c2f66
33d23
< 
48c38
<               mountPath: /export            
---
>               mountPath: /export
69c59
<               memory: 500Mi      
---
>               memory: 500Mi
diff old/persistentvolumeclaim-tensorleap-minio.yaml new/persistentvolumeclaim-tensorleap-minio.yaml
1c1
< # Source: tensorleap/charts/minio/templates/pvc.yaml
---
> # Source: tensorleap/templates/minio-pvc.yaml
6,11d5
<   namespace: "tensorleap"
<   labels:
<     app: minio
<     chart: minio-3.4.3
<     release: tensorleap
<     heritage: Helm
14c8
<     - "ReadWriteOnce"
---
>     - ReadWriteOnce
17,18c11,12
<       storage: "2Gi"
<   volumeName: "minio-data"
---
>       storage: 2Gi
>   volumeName: minio-data
Only in old: service-tensorleap-minio-console.yaml
diff old/service-tensorleap-minio.yaml new/service-tensorleap-minio.yaml
1c1
< # Source: tensorleap/charts/minio/templates/service.yaml
---
> # Source: tensorleap/templates/minio-svc.yaml
6,12d5
<   namespace: "tensorleap"
<   labels:
<     app: minio
<     chart: minio-3.4.3
<     release: tensorleap
<     heritage: Helm
<     monitoring: "true"
diff old/serviceaccount-minio-sa.yaml new/serviceaccount-minio-sa.yaml
1c1
< # Source: tensorleap/charts/minio/templates/serviceaccount.yaml
---
> # Source: tensorleap/templates/minio-sa.yaml
5,6c5
<   name: "minio-sa"
<   namespace: "tensorleap"
---
>   name: minio-sa

```