### PR TITLE
Setup registry for pass-through cache

### DIFF
--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -143,6 +143,47 @@ jobs:
           k3s_version=$(grep 'image:' ./config/k3d-config.yaml | sed 's/.*://;s/-/+/')
           curl -L --fail https://github.com/k3s-io/k3s/releases/download/$k3s_version/k3s-images.txt \
             >> images.txt
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.OPS_SERVICE_ACCOUNT_KEY }}
+      - name: Set up GCloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      - name: Configure docker
+        shell: bash
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev
+      - name: Verify images are in registry
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const TARGET_REPO='us-central1-docker.pkg.dev/tensorleap/main/';
+            const images = fs.readFileSync('images.txt', 'utf-8')
+              .split('\n')
+              .filter(image => image.length > 0);
+
+            for (const image of images) {
+              if (image.startsWith(TARGET_REPO)) {
+                try {
+                  await exec.exec(`skopeo inspect docker://${image}`);
+                  console.log(`Image "${image}" exists!`);
+                } catch (err) {
+                  throw new Error(`image not found: "${image}" ${err}`);
+                }
+              } else {
+                const targetImage = image.replace(/[^\/]*\//, TARGET_REPO);
+                try {
+                  await exec.exec(`skopeo inspect docker://${targetImage}`);
+                  console.log(`Image "${targetImage}" exists!`)
+                } catch (_expected_error) {
+                  try {
+                    await exec.exec(`skopeo copy --all docker://${image} docker://${targetImage}`);
+                  } catch (err)   {
+                    throw new Error(`Failed to copy image: "${image}" ${err}`);
+                  }
+                }
+              }
+            }
       - name: Commit
         uses: EndBug/add-and-commit@v9
         with:

--- a/.github/workflows/update_images.yml
+++ b/.github/workflows/update_images.yml
@@ -135,11 +135,14 @@ jobs:
           rm ./charts/tensorleap/Chart.lock
           helm template ./charts/tensorleap \
             | grep 'image: ' \
-            | grep -v 'tensorleap/engine' \
-            | sed 's/.*: //' \
-            | sed 's/\"//g' \
+            | sed 's/.*: //;s/\"//g' \
             | sort \
             | uniq > images.txt
+      - name: Add k3s images to list
+        run: |
+          k3s_version=$(grep 'image:' ./config/k3d-config.yaml | sed 's/.*://;s/-/+/')
+          curl -L --fail https://github.com/k3s-io/k3s/releases/download/$k3s_version/k3s-images.txt \
+            >> images.txt
       - name: Commit
         uses: EndBug/add-and-commit@v9
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.tgz
 .terraform/
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/config/containerd.toml.tmpl
+++ b/config/containerd.toml.tmpl
@@ -1,0 +1,81 @@
+version = 2
+
+[plugins."io.containerd.internal.v1.opt"]
+  path = "/var/lib/rancher/k3s/agent/containerd"
+[plugins."io.containerd.grpc.v1.cri"]
+  stream_server_address = "127.0.0.1"
+  stream_server_port = "10010"
+  enable_selinux = false
+  enable_unprivileged_ports = true
+  enable_unprivileged_icmp = true
+  sandbox_image = "rancher/mirrored-pause:3.6"
+
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  snapshotter = "overlayfs"
+  disable_snapshot_annotations = true
+
+
+[plugins."io.containerd.grpc.v1.cri".cni]
+  bin_dir = "/bin"
+  conf_dir = "/var/lib/rancher/k3s/agent/etc/cni/net.d"
+
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+  SystemdCgroup = false
+
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.elastic.co"]
+  endpoint = ["http://tensorleap-registry:5000"]
+
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.elastic.co".rewrite]
+    "^(.*)" = "tensorleap/main/$1"
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+  endpoint = ["http://tensorleap-registry:5000"]
+
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io".rewrite]
+    "^(.*)" = "tensorleap/main/$1"
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
+  endpoint = ["http://tensorleap-registry:5000"]
+
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io".rewrite]
+    "^(.*)" = "tensorleap/main/$1"
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."https://us-central1-docker.pkg.dev"]
+  endpoint = ["http://tensorleap-registry:5000"]
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
+  endpoint = ["http://tensorleap-registry:5000"]
+
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io".rewrite]
+    "^(.*)" = "tensorleap/main/$1"
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
+  endpoint = ["http://tensorleap-registry:5000"]
+
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io".rewrite]
+    "^(.*)" = "tensorleap/main/$1"
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."tensorleap-registry:5000"]
+  endpoint = ["http://tensorleap-registry:5000"]
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."tensorleap-registry:5699"]
+  endpoint = ["http://tensorleap-registry:5000"]
+
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."us-central1-docker.pkg.dev"]
+  endpoint = ["http://tensorleap-registry:5000"]

--- a/config/containerd.toml.tmpl
+++ b/config/containerd.toml.tmpl
@@ -34,24 +34,14 @@ version = 2
   endpoint = ["http://tensorleap-registry:5000"]
 
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.elastic.co".rewrite]
-    "^(.*)" = "tensorleap/main/$1"
+    "^elasticsearch/(.*)"= "tensorleap/elasticsearch-$1"
 
 
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
   endpoint = ["http://tensorleap-registry:5000"]
 
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io".rewrite]
-    "^(.*)" = "tensorleap/main/$1"
 
-
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
-  endpoint = ["http://tensorleap-registry:5000"]
-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io".rewrite]
-    "^(.*)" = "tensorleap/main/$1"
-
-
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."https://us-central1-docker.pkg.dev"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."https://registry-1.docker.io"]
   endpoint = ["http://tensorleap-registry:5000"]
 
 
@@ -59,14 +49,14 @@ version = 2
   endpoint = ["http://tensorleap-registry:5000"]
 
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io".rewrite]
-    "^(.*)" = "tensorleap/main/$1"
+    "^ingress-nginx/(.*)"= "tensorleap/ingress-nginx-$1"
 
 
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
   endpoint = ["http://tensorleap-registry:5000"]
 
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io".rewrite]
-    "^(.*)" = "tensorleap/main/$1"
+    "^minio/(.*)"= "tensorleap/minio-$1"
 
 
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."tensorleap-registry:5000"]
@@ -79,3 +69,14 @@ version = 2
 
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."us-central1-docker.pkg.dev"]
   endpoint = ["http://tensorleap-registry:5000"]
+
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."us-central1-docker.pkg.dev".rewrite]
+    "^tensorleap/main/(.*)"= "tensorleap/$1"
+
+
+
+
+
+
+
+

--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -40,28 +40,44 @@ env:
     nodeFilters:
       - server:*
 registries:
-  use:
-    - tensorleap-registry
+  create:
+    name: tensorleap-registry
+    host: "0.0.0.0"
+    hostPort: "5699"
+    proxy:
+      remoteURL: https://us-central1-docker.pkg.dev
+    volumes:
+      - /var/lib/tensorleap/standalone/registry:/var/lib/registry
   config: |
     mirrors:
       docker.io:
         endpoint:
-          - http://k3d-tensorleap-registry:5000
+          - http://tensorleap-registry:5000
+        rewrite:
+          "^(.*)": "tensorleap/main/$1"
       k8s.gcr.io:
         endpoint:
-          - http://k3d-tensorleap-registry:5000
+          - http://tensorleap-registry:5000
+        rewrite:
+          "^(.*)": "tensorleap/main/$1"
       gcr.io:
         endpoint:
-          - http://k3d-tensorleap-registry:5000
+          - http://tensorleap-registry:5000
+        rewrite:
+          "^(.*)": "tensorleap/main/$1"
       docker.elastic.co:
         endpoint:
-          - http://k3d-tensorleap-registry:5000
+          - http://tensorleap-registry:5000
+        rewrite:
+          "^(.*)": "tensorleap/main/$1"
       quay.io:
         endpoint:
-          - http://k3d-tensorleap-registry:5000
+          - http://tensorleap-registry:5000
+        rewrite:
+          "^(.*)": "tensorleap/main/$1"
       us-central1-docker.pkg.dev:
         endpoint:
-          - http://k3d-tensorleap-registry:5000
+          - http://tensorleap-registry:5000
 options:
   k3d:
     disableLoadbalancer: true

--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -2,6 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: tensorleap
+image: rancher/k3s:v1.25.6-k3s1
 volumes:
   - volume: /var/lib/tensorleap/standalone:/var/lib/tensorleap/standalone
     nodeFilters:

--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -48,7 +48,7 @@ registries:
     host: "0.0.0.0"
     hostPort: "5699"
     proxy:
-      remoteURL: https://us-central1-docker.pkg.dev
+      remoteURL: https://registry-1.docker.io
     volumes:
       - /var/lib/tensorleap/standalone/registry:/var/lib/registry
   config: |
@@ -56,31 +56,26 @@ registries:
       docker.io:
         endpoint:
           - http://tensorleap-registry:5000
-        rewrite:
-          "^(.*)": "tensorleap/main/$1"
       k8s.gcr.io:
         endpoint:
           - http://tensorleap-registry:5000
         rewrite:
-          "^(.*)": "tensorleap/main/$1"
-      gcr.io:
-        endpoint:
-          - http://tensorleap-registry:5000
-        rewrite:
-          "^(.*)": "tensorleap/main/$1"
+          "^ingress-nginx/(.*)": "tensorleap/ingress-nginx-$1"
       docker.elastic.co:
         endpoint:
           - http://tensorleap-registry:5000
         rewrite:
-          "^(.*)": "tensorleap/main/$1"
+          "^elasticsearch/(.*)": "tensorleap/elasticsearch-$1"
       quay.io:
         endpoint:
           - http://tensorleap-registry:5000
         rewrite:
-          "^(.*)": "tensorleap/main/$1"
+          "^minio/(.*)": "tensorleap/minio-$1"
       us-central1-docker.pkg.dev:
         endpoint:
           - http://tensorleap-registry:5000
+        rewrite:
+          "^tensorleap/main/(.*)": "tensorleap/$1"
 options:
   k3d:
     disableLoadbalancer: true

--- a/config/k3d-config.yaml
+++ b/config/k3d-config.yaml
@@ -10,6 +10,9 @@ volumes:
   - volume: /var/lib/tensorleap/standalone/manifests/tensorleap.yaml:/var/lib/rancher/k3s/server/manifests/tensorleap.yaml
     nodeFilters:
       - server:*
+  - volume: $PWD/config/containerd.toml.tmpl:/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+    nodeFilters:
+      - server:*
 ports:
   - port: 4589:80
     nodeFilters:

--- a/config/tensorleap.yaml
+++ b/config/tensorleap.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   chart: tensorleap
   repo: https://helm.tensorleap.ai
+  timeout: "2h"
   targetNamespace: tensorleap
 ---
 apiVersion: v1

--- a/images.txt
+++ b/images.txt
@@ -8,3 +8,11 @@ quay.io/minio/minio:RELEASE.2021-12-20T22-07-16Z
 us-central1-docker.pkg.dev/tensorleap/main/engine:master-e66dc6a0-stable
 us-central1-docker.pkg.dev/tensorleap/main/node-server:master-5210b6c7-stable
 us-central1-docker.pkg.dev/tensorleap/main/web-ui:master-17025d5a-stable
+docker.io/rancher/klipper-helm:v0.7.4-build20221121
+docker.io/rancher/klipper-lb:v0.4.0
+docker.io/rancher/local-path-provisioner:v0.0.23
+docker.io/rancher/mirrored-coredns-coredns:1.9.4
+docker.io/rancher/mirrored-library-busybox:1.34.1
+docker.io/rancher/mirrored-library-traefik:2.9.4
+docker.io/rancher/mirrored-metrics-server:v0.6.2
+docker.io/rancher/mirrored-pause:3.6

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ REGISTRY_PORT=${TENSORLEAP_REGISTRY_PORT:=5699}
 USE_LOCAL_HELM=${USE_LOCAL_HELM:=}
 
 USE_GPU=${USE_GPU:=}
-GPU_IMAGE='us-central1-docker.pkg.dev/tensorleap/main/k3s:v1.23.8-k3s1-cuda'
+GPU_IMAGE='us-central1-docker.pkg.dev/tensorleap/main/k3s:v1.25.6-k3s1-cuda'
 
 RETRIES=5
 REQUEST_TIMEOUT=20

--- a/install.sh
+++ b/install.sh
@@ -263,9 +263,8 @@ function download_and_patch_k3d_cluster_config() {
   if [ "$USE_GPU" == "true" ]
   then
     sed_script="$sed_script;
-/volumes:/ i\\
-image: $GPU_IMAGE
-;\$ a\\
+s/image:.*/image: ${GPU_IMAGE//\//\\/}/;
+\$ a\\
 \ \ runtime:\\
 \ \ \ \ gpuRequest: all
 "

--- a/install.sh
+++ b/install.sh
@@ -207,7 +207,7 @@ function init_helm_values() {
 }
 
 function download_and_patch_k3d_cluster_config() {
-  local sed_script="/volumes:/ a\\
+  local sed_script="/^volumes:/ a\\
 \ \ - volume: $DATA_VOLUME\\
 \ \ \ \ nodeFilters:\\
 \ \ \ \ \ \ - server:*
@@ -259,6 +259,7 @@ function init_var_dir() {
   sudo chmod -R 777 $VAR_DIR
   mkdir -p $VAR_DIR/manifests
   mkdir -p $VAR_DIR/storage
+  mkdir -p $VAR_DIR/registry
 
   echo 'Downloading config files...'
   download_and_patch_k3d_cluster_config

--- a/install.sh
+++ b/install.sh
@@ -397,10 +397,18 @@ function check_installed_version() {
   echo Installed Version: $INSTALLED_CHART_VERSION
 }
 
+function cache_engine_image() {
+  local engine_image=$($HTTP_GET https://raw.githubusercontent.com/tensorleap/helm-charts/$FILES_BRANCH/engine-latest-image)
+  report_status "{\"type\":\"install-script-caching-engine-image\",\"installId\":\"$INSTALL_ID\",\"version\":\"$LATEST_CHART_VERSION\"}"
+  
+  $DOCKER exec -d k3d-tensorleap-server-0 crictl pull $engine_image
+}
+
 function install_new_tensorleap_cluster() {
   init_var_dir
   create_data_dir_if_needed
   create_tensorleap_cluster
+  cache_engine_image
 
   if [ "$USE_LOCAL_HELM" == "true" ]; then
     run_helm_install
@@ -414,6 +422,7 @@ function install_new_tensorleap_cluster() {
 
 function update_existing_chart() {
   check_installed_version
+  cache_engine_image
 
   report_status "{\"type\":\"install-script-update-started\",\"installId\":\"$INSTALL_ID\",\"from\":\"$INSTALLED_CHART_VERSION\",\"to\":\"$LATEST_CHART_VERSION\",\"localHelm\":\"$USE_LOCAL_HELM\"}"
 


### PR DESCRIPTION
This replace the current way you cache the needed images on the local machine.
Before this PR we:
1. Pull to local docker client
2. Push to local registry that is created before the cluster
3. The cluster pulls the images from the local registry into the node itself

After this PR:
1. The registry is created along with the cluster, it's state is mapped to local storage
2. The registry is configured to proxy google's artifact registry
3. The is no pre-caching, when the cluster pulls the image from the registry, it is cached and streamed to the cluster in the same time.

Implications:
1. Helm-install timeout was increased to 2 hours, this was not possible before because of a bug that is now fixed https://github.com/k3s-io/helm-controller/pull/150 . This bug was the main reason we chose to do the pre caching in the first place
2. Images that aren't managed by us must be copied to our image registry (artifact registry)
3. Fixed `k3s` images must be used, so we'll know which dependent images to cache. note that we have 2 base images, the standard `k3s` image and the [patched `gpu` image](https://github.com/tensorleap/k3s-image)
4. Currently, this PR **DOESN'T REALLY WORK** because of a bug in `k3d` that fails to [setup the image rewrites](https://docs.k3s.io/installation/private-registry#rewrites), `k3d` team is [working of fixing that bug](https://github.com/k3d-io/k3d/pull/1215). I've **TEMPORARILY** added a commit that simulates the change but we should definitely change wait for the changes to be implemented and update the PR (remove the commit, update the fixed images, update the minimal k3d version in the install script)

### Benchmarks:
on my home network (fiber)
Pull-Push initial installation: 4:55
Second time already cached: 2:22
After making the change: 14:17 👎 - probably because registry is far away?
Second time: 11:18 😱 WTF?