### PR TITLE
Create var dir before caching images

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -396,8 +396,8 @@ function check_installed_version() {
 
 function install_new_tensorleap_cluster() {
   create_docker_registry
-  cache_images_in_registry
   init_var_dir
+  cache_images_in_registry
   create_data_dir_if_needed
   create_tensorleap_cluster
 


### PR DESCRIPTION
This greatly improves the installation because `init_var_dir` always asks for the machine password.
So this flow happens alot:
1. Run installation
2. See the caching is taking long - going for coffee
3. Coming back - machine is waiting for my password
4. Typing password - waiting more for tensorleap to be installed

If you merge this PR the flow becomes:
1. Run installation
2. Machine asks for password, entring
3. Caching is taking long - going for coffee
4. Coming back - browser is open with tensorleap running :)