### PR TITLE
Easy improvments to caching phase

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -208,7 +208,9 @@ function create_docker_registry() {
     report_status "{\"type\":\"install-script-creating-registry\",\"installId\":\"$INSTALL_ID\"}"
     check_docker_requirements
     echo Creating docker registry...
-    $K3D registry create tensorleap-registry -p $REGISTRY_PORT
+    $K3D registry create tensorleap-registry \
+      -p $REGISTRY_PORT \
+      --no-help
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -242,7 +242,7 @@ function cache_images_in_registry() {
     k3s_version=$($K3D version | grep 'k3s version' | sed 's/.*version //;s/ .*//;s/-/+/')
   fi
   cat \
-    <($HTTP_GET https://raw.githubusercontent.com/tensorleap/helm-charts/$FILES_BRANCH/images.txt) \
+    <($HTTP_GET https://raw.githubusercontent.com/tensorleap/helm-charts/$FILES_BRANCH/images.txt | grep -v 'engine') \
     <($HTTP_GET https://github.com/k3s-io/k3s/releases/download/$k3s_version/k3s-images.txt) \
     | xargs -P0 -IXXX bash -c "cache_image $REGISTRY_PORT XXX"
 }

--- a/install.sh
+++ b/install.sh
@@ -384,7 +384,7 @@ function wait_for_cluster_init() {
 }
 
 function check_installed_version() {
-  if run_in_docker kubectl get -n kube-system HelmChart tensorleap;
+  if run_in_docker kubectl get -n kube-system HelmChart tensorleap > /dev/null;
   then
     INSTALLED_CHART_VERSION=$(run_in_docker kubectl get -n kube-system HelmChart tensorleap -o jsonpath='{.spec.version}')
     USE_LOCAL_HELM=false

--- a/install.sh
+++ b/install.sh
@@ -244,7 +244,7 @@ function cache_images_in_registry() {
   cat \
     <($HTTP_GET https://raw.githubusercontent.com/tensorleap/helm-charts/$FILES_BRANCH/images.txt) \
     <($HTTP_GET https://github.com/k3s-io/k3s/releases/download/$k3s_version/k3s-images.txt) \
-    | xargs -P3 -IXXX bash -c "cache_image $REGISTRY_PORT XXX"
+    | xargs -P0 -IXXX bash -c "cache_image $REGISTRY_PORT XXX"
 }
 
 function init_helm_values() {


### PR DESCRIPTION
This adds the following changes which *DOES NOT* require re-installation

1. Output is less verbose - removed the registry "help message" and the progress bars of docker pull/push
2. Run all the pull/pushs in parallel instead of only 3 at once
3. Registry data is mounted to a local volume, you can check it's size with `du -hd0 /var/lib/tensorleap/standalone/registry`
4. Engine is NOT cached along with the other images, instead, after everything is ready, it is cache from inside the docker image and pushed to registry (in the background)
