### PR TITLE
Add node server permission tp read secret due to migratin

### DIFF
--- a/charts/tensorleap/charts/node-server/templates/role.yaml
+++ b/charts/tensorleap/charts/node-server/templates/role.yaml
@@ -17,6 +17,7 @@ rules:
     resources:
       - secrets
     verbs:
+      - get
       - create
       - delete
       - update


### PR DESCRIPTION
This pr created due to migrate kubernetes secrets to mongo db so the node server migration needs to read secrets and encrypt them to mongo.
After the migration I'll remove the whole section of secrets here