### PR TITLE
hide keycloak admin

### DIFF
--- a/charts/tensorleap/charts/node-server/templates/ingress.yaml
+++ b/charts/tensorleap/charts/node-server/templates/ingress.yaml
@@ -42,6 +42,13 @@ spec:
                 name: keycloak-http
                 port:
                   name: http
-            path: /auth
+            path: /auth/realms
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: keycloak-http
+                port:
+                  name: http
+            path: /auth/resources
             pathType: ImplementationSpecific
 {{ end }}


### PR DESCRIPTION
- Do not expose keycloak admin pages in ingress
- Bump chart versions
