### PR TITLE
chore: upgrade keycloak chart to keycloakx

### DIFF
--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -7,8 +7,9 @@ dependencies:
     version: 4.10.0
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
-  - name: keycloak
-    version: "18.4.4"
+  - name: keycloakx
+    alias: keycloak
+    version: "26.0.3"
     repository: "https://codecentric.github.io/helm-charts"
   - name: datadog
     version: 3.59.2

--- a/charts/tensorleap/values.yaml
+++ b/charts/tensorleap/values.yaml
@@ -37,12 +37,14 @@ global:
 keycloak:
   replicas: 1
   extraEnv: |
-    - name: KEYCLOAK_USER
+    - name: KEYCLOAK_ADMIN
       value: admin
-    - name: KEYCLOAK_PASSWORD
+    - name: KEYCLOAK_ADMIN_PASSWORD
       value: admin
-    - name: PROXY_ADDRESS_FORWARDING
-      value: "true"
+    - name: KC_PROXY
+      value: "edge"
+    - name: KC_HTTP_RELATIVE_PATH
+      value: "/auth"
 
   fullnameOverride: keycloak
   ingress:

--- a/images.txt
+++ b/images.txt
@@ -14,7 +14,7 @@ public.ecr.aws/tensorleap/engine:master-ce96dd5c
 public.ecr.aws/tensorleap/node-server:master-14dbfb9f
 public.ecr.aws/tensorleap/pippin:master-429ecc32
 public.ecr.aws/tensorleap/web-ui:master-d6547722
-quay.io/keycloak/keycloak:17.0.1-legacy
+quay.io/keycloak/keycloak:26.0.3
 quay.io/minio/minio:RELEASE.2021-12-20T22-07-16Z
 registry.k8s.io/ingress-nginx/controller:v1.10.0
 registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0

--- a/pkg/helm/utils.go
+++ b/pkg/helm/utils.go
@@ -203,14 +203,15 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 		Value string `yaml:"value"`
 	}
 
-	extraEnvSlice := []ExtraEnv{
-		{Name: "KEYCLOAK_USER", Value: "admin"},
-		{Name: "KEYCLOAK_PASSWORD", Value: "admin"},
-		{Name: "PROXY_ADDRESS_FORWARDING", Value: "true"},
-	}
-	if params.ProxyUrl != "" {
-		extraEnvSlice = append(extraEnvSlice, ExtraEnv{Name: "KEYCLOAK_FRONTEND_URL", Value: fmt.Sprintf("%s/auth", params.ProxyUrl)})
-	}
+        extraEnvSlice := []ExtraEnv{
+                {Name: "KEYCLOAK_ADMIN", Value: "admin"},
+                {Name: "KEYCLOAK_ADMIN_PASSWORD", Value: "admin"},
+                {Name: "KC_PROXY", Value: "edge"},
+                {Name: "KC_HTTP_RELATIVE_PATH", Value: "/auth"},
+        }
+        if params.ProxyUrl != "" {
+                extraEnvSlice = append(extraEnvSlice, ExtraEnv{Name: "KC_HOSTNAME_URL", Value: fmt.Sprintf("%s/auth", params.ProxyUrl)})
+        }
 	formatExtraEnv := func(extraEnv []ExtraEnv) string {
 		result, _ := yaml.Marshal(extraEnv)
 		resultString := "\n" + string(result)

--- a/pkg/helm/utils_test.go
+++ b/pkg/helm/utils_test.go
@@ -54,7 +54,7 @@ func TestCreateTensorleapChartValues(t *testing.T) {
 			},
 			"keycloak": map[string]interface{}{
 				"replicas": 1,
-				"extraEnv": "\n- name: KEYCLOAK_USER\n  value: admin\n- name: KEYCLOAK_PASSWORD\n  value: admin\n- name: PROXY_ADDRESS_FORWARDING\n  value: \"true\"\n",
+                                "extraEnv": "\n- name: KEYCLOAK_ADMIN\n  value: admin\n- name: KEYCLOAK_ADMIN_PASSWORD\n  value: admin\n- name: KC_PROXY\n  value: edge\n- name: KC_HTTP_RELATIVE_PATH\n  value: /auth\n",
 			},
 		}
 


### PR DESCRIPTION
## Summary
- switch to codecentric keycloakx chart and keep `/auth` pathing
- update env vars to include relative path and hostname URL
- refresh keycloak image list entry

## Testing
- `go test ./...` *(fails: Get "https://api.github.com/repos/tensorleap/helm-charts/releases?page=1&per_page=10": Forbidden; failed fetching latest k3s images: Get "https://github.com/k3s-io/k3s/releases/download/v1.26.4+k3s1/k3s-images.txt": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68949f2d0028833397002bf2a1fc1a43