### PR TITLE
chore: switch to keycloakx with file-based db

### DIFF
--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -7,10 +7,10 @@ dependencies:
     version: 4.10.0
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
-  - name: keycloak
-    version: "18.4.4"
+  - name: keycloakx
+    version: "24.0.4"
     repository: "https://codecentric.github.io/helm-charts"
-    condition: keycloak.enabled
+    condition: keycloakx.enabled
   - name: datadog
     version: 3.59.2
     repository: https://helm.datadoghq.com

--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
   - name: keycloakx
-    version: "24.0.4"
+    version: "7.1.2"
     repository: "https://codecentric.github.io/helm-charts"
     condition: keycloakx.enabled
   - name: datadog

--- a/charts/tensorleap/charts/node-server/templates/ingress.yaml
+++ b/charts/tensorleap/charts/node-server/templates/ingress.yaml
@@ -40,6 +40,13 @@ spec:
                 name: keycloak-http
                 port:
                   name: http
-            path: /auth
-            pathType: Prefix
+            path: /auth/realms
+            pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: keycloak-http
+                port:
+                  name: http
+            path: /auth/resources
+            pathType: ImplementationSpecific
 {{ end }}

--- a/charts/tensorleap/charts/node-server/templates/ingress.yaml
+++ b/charts/tensorleap/charts/node-server/templates/ingress.yaml
@@ -40,13 +40,6 @@ spec:
                 name: keycloak-http
                 port:
                   name: http
-            path: /auth/realms
-            pathType: ImplementationSpecific
-          - backend:
-              service:
-                name: keycloak-http
-                port:
-                  name: http
-            path: /auth/resources
-            pathType: ImplementationSpecific
+            path: /auth
+            pathType: Prefix
 {{ end }}

--- a/charts/tensorleap/templates/keycloak-data-pvc.yaml
+++ b/charts/tensorleap/templates/keycloak-data-pvc.yaml
@@ -1,8 +1,8 @@
-{{ if and .Values.keycloak.enabled .Values.global.create_local_volumes  }}
+{{ if and .Values.keycloakx.enabled .Values.global.create_local_volumes  }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: keycloak-postgresql-data
+  name: keycloak-data
 spec:
   storageClassName: local-path
   accessModes:
@@ -10,18 +10,18 @@ spec:
   capacity:
     storage: 8Gi
   hostPath:
-    path: /var/lib/tensorleap/standalone/storage/keycloak-postgresql
+    path: /var/lib/tensorleap/standalone/storage/keycloak
     type: DirectoryOrCreate
   claimRef:
-    name: keycloak-postgresql-data
+    name: keycloak-data
     namespace: {{ .Release.Namespace }}
 {{ end }}
 ---
-{{ if .Values.keycloak.enabled }}
+{{ if .Values.keycloakx.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: keycloak-postgresql-data
+  name: keycloak-data
 spec:
   accessModes:
     - ReadWriteOnce
@@ -29,7 +29,7 @@ spec:
     requests:
       storage: 8Gi
 {{ if .Values.global.create_local_volumes }}
-  volumeName: keycloak-postgresql-data
+  volumeName: keycloak-data
 {{ else if .Values.global.storageClassName }}
   storageClassName: {{ .Values.global.storageClassName }}
 {{ end }}

--- a/charts/tensorleap/values.yaml
+++ b/charts/tensorleap/values.yaml
@@ -8,32 +8,32 @@ ingress-nginx:
     extraArgs:
       default-ssl-certificate: tensorleap/tls-secret
     image:
-      digest: ''
+      digest: ""
     config:
       enable-snippets: "true"
       allow-snippet-annotations: "true"
     admissionWebhooks:
       patch:
         image:
-          digest: ''
+          digest: ""
 
 global:
-  target_namespace: ''
-  storageClassName: ''
+  target_namespace: ""
+  storageClassName: ""
   create_local_volumes: true
   disable_auth: false
-  domain: 'localhost'
-  basePath: ''
-  url: 'http://localhost'
-  proxyUrl: ''
+  domain: "localhost"
+  basePath: ""
+  url: "http://localhost"
+  proxyUrl: ""
   tls:
     enabled: false
-    cert: ''
-    key: ''
+    cert: ""
+    key: ""
 
   elasticsearch:
     enabled: true
-    url: ''
+    url: ""
 
   keycloakx:
     enabled: true
@@ -41,6 +41,7 @@ global:
 keycloakx:
   enabled: true
   replicas: 1
+  command: ["/opt/keycloak/bin/kc.sh", "start"]
   extraEnv: |
     - name: KEYCLOAK_ADMIN
       value: admin
@@ -52,13 +53,18 @@ keycloakx:
       value: "edge"
     - name: KC_HTTP_RELATIVE_PATH
       value: /auth
-
+    - name: KC_HOSTNAME_STRICT
+      value: "false"
+    - name: KC_CACHE
+      value: "local"
   fullnameOverride: keycloak
   ingress:
     enabled: false
   persistence:
     enabled: true
     existingClaim: "keycloak-data"
+    size: 8Gi
+    storageClass: "local-path"
 datadog:
   enabled: true
   clusterAgent:

--- a/charts/tensorleap/values.yaml
+++ b/charts/tensorleap/values.yaml
@@ -35,28 +35,30 @@ global:
     enabled: true
     url: ''
 
-keycloak:
+  keycloakx:
+    enabled: true
+
+keycloakx:
   enabled: true
   replicas: 1
   extraEnv: |
-    - name: KEYCLOAK_USER
+    - name: KEYCLOAK_ADMIN
       value: admin
-    - name: KEYCLOAK_PASSWORD
+    - name: KEYCLOAK_ADMIN_PASSWORD
       value: admin
-    - name: PROXY_ADDRESS_FORWARDING
-      value: "true"
+    - name: KC_DB
+      value: dev-file
+    - name: KC_PROXY
+      value: "edge"
+    - name: KC_HTTP_RELATIVE_PATH
+      value: /auth
 
   fullnameOverride: keycloak
   ingress:
     enabled: false
-  postgresql:
-    fullnameOverride: "keycloak-postgresql"
-    persistence:
-      enabled: true
-      existingClaim: "keycloak-postgresql-data"
-  pgchecker:
-    image:
-      repository: docker.io/library/busybox # must to add the library before the image name for air-gapped environments
+  persistence:
+    enabled: true
+    existingClaim: "keycloak-data"
 datadog:
   enabled: true
   clusterAgent:

--- a/images.txt
+++ b/images.txt
@@ -1,5 +1,4 @@
 docker.elastic.co/eck/eck-operator:2.8.0
-docker.io/bitnami/postgresql:11.14.0-debian-10-r28
 docker.io/library/busybox:1.32
 docker.io/library/elasticsearch:8.10.1
 docker.io/library/mongo:6.0.5
@@ -14,7 +13,7 @@ public.ecr.aws/tensorleap/engine:master-70dad86d
 public.ecr.aws/tensorleap/node-server:master-b4855f99
 public.ecr.aws/tensorleap/pippin:master-429ecc32
 public.ecr.aws/tensorleap/web-ui:master-794be422
-quay.io/keycloak/keycloak:17.0.1-legacy
+quay.io/keycloak/keycloak:24.0.4
 quay.io/minio/minio:RELEASE.2021-12-20T22-07-16Z
 registry.k8s.io/ingress-nginx/controller:v1.10.0
 registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0

--- a/images.txt
+++ b/images.txt
@@ -1,5 +1,4 @@
 docker.elastic.co/eck/eck-operator:2.8.0
-docker.io/library/busybox:1.32
 docker.io/library/elasticsearch:8.10.1
 docker.io/library/mongo:6.0.5
 docker.io/library/rabbitmq:3.9.22
@@ -13,7 +12,7 @@ public.ecr.aws/tensorleap/engine:master-70dad86d
 public.ecr.aws/tensorleap/node-server:master-b4855f99
 public.ecr.aws/tensorleap/pippin:master-429ecc32
 public.ecr.aws/tensorleap/web-ui:master-794be422
-quay.io/keycloak/keycloak:24.0.4
+quay.io/keycloak/keycloak:26.3.2
 quay.io/minio/minio:RELEASE.2021-12-20T22-07-16Z
 registry.k8s.io/ingress-nginx/controller:v1.10.0
 registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0

--- a/pkg/helm/utils.go
+++ b/pkg/helm/utils.go
@@ -205,12 +205,14 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 	}
 
 	extraEnvSlice := []ExtraEnv{
-		{Name: "KEYCLOAK_USER", Value: "admin"},
-		{Name: "KEYCLOAK_PASSWORD", Value: "admin"},
-		{Name: "PROXY_ADDRESS_FORWARDING", Value: "true"},
+		{Name: "KEYCLOAK_ADMIN", Value: "admin"},
+		{Name: "KEYCLOAK_ADMIN_PASSWORD", Value: "admin"},
+		{Name: "KC_DB", Value: "dev-file"},
+		{Name: "KC_PROXY", Value: "edge"},
+		{Name: "KC_HTTP_RELATIVE_PATH", Value: "/auth"},
 	}
 	if params.ProxyUrl != "" {
-		extraEnvSlice = append(extraEnvSlice, ExtraEnv{Name: "KEYCLOAK_FRONTEND_URL", Value: fmt.Sprintf("%s/auth", params.ProxyUrl)})
+		extraEnvSlice = append(extraEnvSlice, ExtraEnv{Name: "KC_HOSTNAME_URL", Value: fmt.Sprintf("%s/auth", params.ProxyUrl)})
 	}
 	formatExtraEnv := func(extraEnv []ExtraEnv) string {
 		result, _ := yaml.Marshal(extraEnv)
@@ -242,7 +244,7 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 			"basePath":             params.BasePath,
 			"create_local_volumes": true,
 			"storageClassName":     "",
-			"keycloak": Record{
+			"keycloakx": Record{
 				"enabled": params.KeycloakEnabled,
 			},
 			"tls": Record{
@@ -251,7 +253,7 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 				"key":     params.Tls.Key,
 			},
 		},
-		"keycloak": map[string]interface{}{
+		"keycloakx": map[string]interface{}{
 			"enabled":  params.KeycloakEnabled,
 			"replicas": 1,
 			"extraEnv": extraEnvStringYaml,

--- a/pkg/helm/utils.go
+++ b/pkg/helm/utils.go
@@ -210,6 +210,8 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 		{Name: "KC_DB", Value: "dev-file"},
 		{Name: "KC_PROXY", Value: "edge"},
 		{Name: "KC_HTTP_RELATIVE_PATH", Value: "/auth"},
+		{Name: "KC_HOSTNAME_STRICT", Value: "false"},
+		{Name: "KC_CACHE", Value: "local"},
 	}
 	if params.ProxyUrl != "" {
 		extraEnvSlice = append(extraEnvSlice, ExtraEnv{Name: "KC_HOSTNAME_URL", Value: fmt.Sprintf("%s/auth", params.ProxyUrl)})
@@ -256,6 +258,7 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 		"keycloakx": map[string]interface{}{
 			"enabled":  params.KeycloakEnabled,
 			"replicas": 1,
+			"command":  []string{"/opt/keycloak/bin/kc.sh", "start-dev"},
 			"extraEnv": extraEnvStringYaml,
 		},
 		"datadog": map[string]interface{}{

--- a/pkg/helm/utils_test.go
+++ b/pkg/helm/utils_test.go
@@ -62,7 +62,8 @@ func TestCreateTensorleapChartValues(t *testing.T) {
 			"keycloakx": map[string]interface{}{
 				"enabled":  true,
 				"replicas": 1,
-				"extraEnv": "\n- name: KEYCLOAK_ADMIN\n  value: admin\n- name: KEYCLOAK_ADMIN_PASSWORD\n  value: admin\n- name: KC_DB\n  value: dev-file\n- name: KC_PROXY\n  value: \"edge\"\n- name: KC_HTTP_RELATIVE_PATH\n  value: /auth\n",
+				"command":  []string{"/opt/keycloak/bin/kc.sh", "start-dev"},
+				"extraEnv": "\n- name: KEYCLOAK_ADMIN\n  value: admin\n- name: KEYCLOAK_ADMIN_PASSWORD\n  value: admin\n- name: KC_DB\n  value: dev-file\n- name: KC_PROXY\n  value: \"edge\"\n- name: KC_HTTP_RELATIVE_PATH\n  value: /auth\n- name: KC_HOSTNAME_STRICT\n  value: \"false\"\n- name: KC_CACHE\n  value: local\n",
 			},
 		}
 

--- a/pkg/helm/utils_test.go
+++ b/pkg/helm/utils_test.go
@@ -39,7 +39,7 @@ func TestCreateTensorleapChartValues(t *testing.T) {
 				"basePath":             "",
 				"create_local_volumes": true,
 				"storageClassName":     "",
-				"keycloak": Record{
+				"keycloakx": Record{
 					"enabled": true,
 				},
 				"tls": Record{
@@ -59,10 +59,10 @@ func TestCreateTensorleapChartValues(t *testing.T) {
 					},
 				},
 			},
-			"keycloak": map[string]interface{}{
+			"keycloakx": map[string]interface{}{
 				"enabled":  true,
 				"replicas": 1,
-				"extraEnv": "\n- name: KEYCLOAK_USER\n  value: admin\n- name: KEYCLOAK_PASSWORD\n  value: admin\n- name: PROXY_ADDRESS_FORWARDING\n  value: \"true\"\n",
+				"extraEnv": "\n- name: KEYCLOAK_ADMIN\n  value: admin\n- name: KEYCLOAK_ADMIN_PASSWORD\n  value: admin\n- name: KC_DB\n  value: dev-file\n- name: KC_PROXY\n  value: \"edge\"\n- name: KC_HTTP_RELATIVE_PATH\n  value: /auth\n",
 			},
 		}
 

--- a/pkg/local/utils.go
+++ b/pkg/local/utils.go
@@ -15,17 +15,17 @@ import (
 )
 
 const (
-	DATA_DIR_ENV_NAME                  = "TL_DATA_DIR"
-	DEFAULT_DATA_DIR                   = "/var/lib/tensorleap/standalone"
-	REGISTRY_DIR_NAME                  = "registry"
-	LOGS_DIR_NAME                      = "logs"
-	STORAGE_DIR_NAME                   = "storage"
-	ELASTIC_STORAGE_DIR_NAME           = "storage/keycloak-postgresql"
-	KECKLOCK_POSTGRES_STORAGE_DIR_NAME = "storage/elasticsearch"
-	HOSTNAME_FILE                      = "hostname"
-	MANIFEST_DIR_NAME                  = "manifests"
-	INSTALLATION_PARAMS_FILE_NAME      = "params.yaml"
-	INSTALLATION_MANIFEST_FILE_NAME    = "manifest.yaml"
+	DATA_DIR_ENV_NAME               = "TL_DATA_DIR"
+	DEFAULT_DATA_DIR                = "/var/lib/tensorleap/standalone"
+	REGISTRY_DIR_NAME               = "registry"
+	LOGS_DIR_NAME                   = "logs"
+	STORAGE_DIR_NAME                = "storage"
+	KEYCLOAK_DB_STORAGE_DIR_NAME    = "storage/keycloak-db"
+	ELASTIC_STORAGE_DIR_NAME        = "storage/elasticsearch"
+	HOSTNAME_FILE                   = "hostname"
+	MANIFEST_DIR_NAME               = "manifests"
+	INSTALLATION_PARAMS_FILE_NAME   = "params.yaml"
+	INSTALLATION_MANIFEST_FILE_NAME = "manifest.yaml"
 )
 
 func GetServerDataDir() string {
@@ -94,7 +94,7 @@ func InitStandaloneDir() error {
 
 func initStandaloneSubDirs() error {
 	standaloneDir := GetServerDataDir()
-	subDirs := []string{STORAGE_DIR_NAME, REGISTRY_DIR_NAME, LOGS_DIR_NAME, MANIFEST_DIR_NAME, ELASTIC_STORAGE_DIR_NAME, KECKLOCK_POSTGRES_STORAGE_DIR_NAME}
+	subDirs := []string{STORAGE_DIR_NAME, REGISTRY_DIR_NAME, LOGS_DIR_NAME, MANIFEST_DIR_NAME, KEYCLOAK_DB_STORAGE_DIR_NAME, ELASTIC_STORAGE_DIR_NAME}
 	for _, dir := range subDirs {
 		fullPath := path.Join(standaloneDir, dir)
 		_, err := os.Stat(fullPath)

--- a/pkg/local/utils.go
+++ b/pkg/local/utils.go
@@ -20,7 +20,7 @@ const (
 	REGISTRY_DIR_NAME               = "registry"
 	LOGS_DIR_NAME                   = "logs"
 	STORAGE_DIR_NAME                = "storage"
-	KEYCLOAK_DB_STORAGE_DIR_NAME    = "storage/keycloak-db"
+	KEYCLOAK_DB_STORAGE_DIR_NAME    = "storage/keycloak"
 	ELASTIC_STORAGE_DIR_NAME        = "storage/elasticsearch"
 	HOSTNAME_FILE                   = "hostname"
 	MANIFEST_DIR_NAME               = "manifests"


### PR DESCRIPTION
## Summary
- switch chart dependency to KeycloakX and remove Postgres
- serve Keycloak under /auth and persist local file-based DB
- update Helm utilities and image list for new Keycloak

## Testing
- `go test ./...` *(fails: command hung due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68a6e8175b4c8333a198773a0bb99b71