### PR TITLE
Remove duplicate "Using tag" log from LoadManifestOnly

### DIFF
--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -147,7 +147,6 @@ func LoadManifestOnly(flags *InstallationSourceFlags, previousMnf *manifest.Inst
 				return nil, false, err
 			}
 		}
-		log.Info("Using tag: " + mnf.Tag)
 	}
 	if err != nil {
 		log.SendCloudReport("error", "Build manifest failed", "Failed",


### PR DESCRIPTION
The install command pre-checks reinstall via `LoadManifestOnly` before loading heavy assets, then runs `InitInstallationProcess` — both functions logged `Using tag: <tag>`, so install printed it twice. Drop the log from `LoadManifestOnly`; `InitInstallationProcess` still emits it once (and upgrade/reinstall paths are unaffected).

Fixes [EN-2205](https://tensorleap.atlassian.net/browse/EN-2205).

[EN-2205]: https://tensorleap.atlassian.net/browse/EN-2205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ