### PR TITLE
Add optional cli_tag input to _install_server.yml

### DIFF
--- a/.github/workflows/_install_server.yml
+++ b/.github/workflows/_install_server.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ''
         type: string
+      cli_tag:
+        description: 'leap-cli release tag to install, e.g. v0.0.151 (omit or leave empty to install latest)'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   install-server:
@@ -16,7 +21,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Install leap-cli
+        env:
+          CLI_TAG: ${{ inputs.cli_tag }}
         run: |
+          if [ -n "$CLI_TAG" ]; then
+            echo "Installing leap-cli pinned to tag: $CLI_TAG"
+            export TAG="$CLI_TAG"
+          else
+            echo "Installing latest leap-cli"
+          fi
           curl -s https://raw.githubusercontent.com/tensorleap/leap-cli/master/install.sh | bash
           if [ $? -ne 0 ]; then
             echo "❌ leap-cli installation failed"

--- a/.github/workflows/_install_server.yml
+++ b/.github/workflows/_install_server.yml
@@ -22,11 +22,12 @@ jobs:
     steps:
       - name: Install leap-cli
         env:
-          CLI_TAG: ${{ inputs.cli_tag }}
+          # install.sh reads $TAG from the environment to pin the release; empty = latest.
+          # See leap-cli/install.sh checkTagProvided().
+          TAG: ${{ inputs.cli_tag }}
         run: |
-          if [ -n "$CLI_TAG" ]; then
-            echo "Installing leap-cli pinned to tag: $CLI_TAG"
-            export TAG="$CLI_TAG"
+          if [ -n "$TAG" ]; then
+            echo "Installing leap-cli pinned to tag: $TAG"
           else
             echo "Installing latest leap-cli"
           fi


### PR DESCRIPTION
## Summary
- Adds an optional `cli_tag` input to the reusable `_install_server.yml` workflow.
- When set, the leap-cli install step exports `TAG=$cli_tag` before piping to `install.sh`, which pins the binary to the given GitHub release tag (e.g. `v0.0.151`).
- Default is empty (`''`) = install latest, preserving current behavior for existing callers (`release_candidate.yml`, `release_production.yml`, `patch.yml`).

## Why
New nightly automation workflows in [`tensorleap/quality`](https://github.com/tensorleap/quality) need to pin both the server manifest tag and the leap-cli release tag. The server tag was already supported; this PR adds the CLI tag knob.

## Test plan
- [ ] Existing callers continue to install the latest leap-cli (they pass only `tag:`, no `cli_tag:`).
- [ ] A caller that passes `cli_tag: v0.0.151` installs leap-cli pinned to v0.0.151.
- [ ] A caller that passes `cli_tag: ''` (empty) installs latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)