### PR TITLE
node-server: lower db-migration boundary 134 → 132

### DIFF
--- a/charts/tensorleap/charts/node-server/templates/deployment.yaml
+++ b/charts/tensorleap/charts/node-server/templates/deployment.yaml
@@ -50,10 +50,23 @@ spec:
                 name: tensorleap-node-server-env-configmap
           env:
             # Phase 1: up to and including the special-migration boundary.
-            # Migrations after this index assume sessions-to-versions has
-            # already produced the new versions/resources shape.
+            # Migrations strictly after this index assume sessions-to-versions
+            # has already (a) populated `inferenceArtifactId` on versions
+            # and (b) finished the storage-tasks K8s Job that moves files
+            # to the new `inference/<id>/` / `vis/<id>/` layout.
+            #
+            # Boundary = 132 (not 134) because migration 133 backfills
+            # `graphValidationData.available_latent_spaces` by reading a
+            # PCA manifest at the *new* storage path, so it needs both of
+            # the above. Running it pre-sessions defaults every version
+            # to `[{default, balanced}]` and the script's idempotency
+            # guard (`$exists: true`) prevents a corrective re-run.
+            # Migration 134 is version/session-independent (only cleans up
+            # `under_representation` references in insights/jobs/etc.) so
+            # it can safely live in post — keeping it together with 133
+            # avoids splitting consecutive numbered files across phases.
             - name: MIGRATION_TO
-              value: "{{ .Values.db_migration_special_boundary | default 134 }}"
+              value: "{{ .Values.db_migration_special_boundary | default 132 }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -153,9 +166,10 @@ spec:
                 name: tensorleap-node-server-env-configmap
           env:
             # Phase 2: pick up where pre left off — anything STRICTLY
-            # above the boundary the pre pass capped at.
+            # above the boundary the pre pass capped at. Default must match
+            # the pre-pass MIGRATION_TO default above (currently 132).
             - name: MIGRATION_FROM
-              value: "{{ add (.Values.db_migration_special_boundary | default 134 | int) 1 }}"
+              value: "{{ add (.Values.db_migration_special_boundary | default 132 | int) 1 }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Summary

Migration 133 (\`versions-graph-validation-available-latent-spaces\`) runs in \`db-migration-pre\` today, *before* \`migrate-sessions-to-versions\`, but it reads data only that special migration produces:

- \`version.inferenceArtifactId\` — set by sessions-to-versions when absorbing a sessionRun
- PCA manifest at the **new** storage path \`organizations/<t>/projects/<p>/inference/<id>/latent_space/pca_ready/…\` — only present after the storage-tasks K8s Job drains

Running pre-sessions made 133 default every version to the \`[{default, balanced}]\` sentinel (verified on my local helm cluster — \`[versions] Candidate versions: 2\`, both stamped with the default). The script's own idempotency guard (\`available_latent_spaces\` \`\$exists: false\`) then blocks corrective re-runs.

**Fix**: lower the boundary so 133 runs in \`db-migration-post\`, which already waits for storage tasks to drain before running its window. 134 is version/session-independent (only cleans up \`under_representation\` references in insights/jobs/etc.) so it rides along — keeps consecutive numbered files together in one phase.

Both call sites updated (\`MIGRATION_TO\` in pre, \`MIGRATION_FROM\` in post) so the defaults stay in sync.

## Test plan
- [x] \`helm template\` renders \`MIGRATION_TO=132\` in pre and \`MIGRATION_FROM=133\` in post
- [ ] Bake an image off node-server PR #1718 (graphValidationData on clones), redeploy a fresh-from-old install, watch:
  - pre runs 131, 132 only
  - sessions-to-versions runs
  - storage-tasks Job drains
  - post runs 133 (each new version gets correct \`available_latent_spaces\` from the PCA manifest), 134, 135+

## Related
- node-server #1718 — carry \`graphValidationData\` onto cloned versions (so 133's \`\$exists: true\` filter actually matches clones)
- node-server #1717 — storage-tasks fallbackFrom + 404 fixes (so the PCA files actually land at the new path 133 looks at)