### PR TITLE
Default 'leap server upgrade' confirmation to Yes

### DIFF
--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -248,7 +248,7 @@ func IsUseDefaultPropOption() bool {
 }
 
 func AskUserForIsUseLatestVersion(previousTag string) (bool, error) {
-	isInstallLatestVersion := false
+	isInstallLatestVersion := true
 
 	if IsUseDefaultPropOption() {
 		return isInstallLatestVersion, nil
@@ -257,10 +257,10 @@ func AskUserForIsUseLatestVersion(previousTag string) (bool, error) {
 	latestTag, err := manifest.GetLatestManifestTag()
 	if err != nil {
 		log.Warnf("Failed to get latest manifest tag: %v", err)
-		return isInstallLatestVersion, nil
+		return false, nil
 	}
 	if latestTag == previousTag {
-		return isInstallLatestVersion, nil
+		return false, nil
 	}
 
 	prompt := survey.Confirm{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 
 // When upgrading major number(the middle digit) it will require reinstall
 
-const Version = "v0.10.3"
+const Version = "v0.10.4"
 
 func IsMinorVersionSmaller(currentVersion, comperedVersion string) bool {
 


### PR DESCRIPTION
The "Do you want to use latest version?" prompt defaulted to No (y/N).
Since the user explicitly invoked `leap server upgrade`, default to Yes
(Y/n).

Also fixes the non-interactive path: `leap server upgrade -y` (which
sets `TL_USE_DEFAULT_OPTION=true`) now returns `true` and actually
upgrades to the latest tag, instead of staying on the current one.

EN-2254