### PR TITLE
Plumb --disable-auth to node-server DISABLE_AUTH env var

### DIFF
--- a/charts/tensorleap/charts/node-server/templates/node-server-env-configmap.yaml
+++ b/charts/tensorleap/charts/node-server/templates/node-server-env-configmap.yaml
@@ -22,6 +22,7 @@ data:
   KEYCLOAK_CLUSTER_URL: "http://keycloak-http.{{ .Release.Namespace }}.svc.cluster.local/auth"
   KEYCLOAK_REALM: "tensorleap"
   ENABLE_KEYCLOAK_AUTH: {{ .Values.enableKeycloak | quote }}
+  DISABLE_AUTH: {{ .Values.disableAuth | quote }}
   KEYCLOAK_RESOURCE: "tensorleap-client"
   KEYCLOAK_ADMIN_USER_NAME: "admin"
   KEYCLOAK_ADMIN_PASSWORD: "admin"

--- a/charts/tensorleap/charts/node-server/values.yaml
+++ b/charts/tensorleap/charts/node-server/values.yaml
@@ -2,6 +2,7 @@ image_tag: master-7898214a
 image: public.ecr.aws/tensorleap/node-server
 disableDatadogMetrics: false
 enableKeycloak: true
+disableAuth: false
 installedServerVersion: "unknown"
 
 ingress:

--- a/pkg/helm/utils.go
+++ b/pkg/helm/utils.go
@@ -38,6 +38,7 @@ type ServerHelmValuesParams struct {
 	HostName               string            `json:"hostname"`
 	DatadogEnv             map[string]string `json:"datadogEnv"`
 	KeycloakEnabled        bool              `json:"keycloakEnabled"`
+	DisableAuth            bool              `json:"disableAuth"`
 	InstalledServerVersion string            `json:"installedServerVersion"`
 	LocalBucketPath        string            `json:"localBucketPath"`
 }
@@ -257,6 +258,7 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 		},
 		"tensorleap-node-server": Record{
 			"enableKeycloak":         params.KeycloakEnabled,
+			"disableAuth":            params.DisableAuth,
 			"disableDatadogMetrics":  params.DisableDatadogMetrics,
 			"installedServerVersion": params.InstalledServerVersion,
 			"localBucketPath":        params.LocalBucketPath,

--- a/pkg/helm/utils_test.go
+++ b/pkg/helm/utils_test.go
@@ -30,6 +30,7 @@ func TestCreateTensorleapChartValues(t *testing.T) {
 			},
 			"tensorleap-node-server": Record{
 				"enableKeycloak":         params.KeycloakEnabled,
+				"disableAuth":            params.DisableAuth,
 				"disableDatadogMetrics":  params.DisableDatadogMetrics,
 				"installedServerVersion": params.InstalledServerVersion,
 				"localBucketPath":        params.LocalBucketPath,

--- a/pkg/server/installation_params.go
+++ b/pkg/server/installation_params.go
@@ -851,6 +851,7 @@ func (params *InstallationParams) GetServerHelmValuesParams(versionTag string) *
 		Tls:                    *tlsParams,
 		DatadogEnv:             datadogEnvs,
 		KeycloakEnabled:        !params.DisabledAuth,
+		DisableAuth:            params.DisabledAuth,
 		InstalledServerVersion: versionTag,
 		LocalBucketPath:        localBucketPath,
 	}


### PR DESCRIPTION
## Why

`leap server install --disable-auth` already maps to `enableKeycloak=false` (and stops deploying Keycloak), but that only switches node-server into *local* auth mode — which still requires a real login / API key. So the **leap CLI** still can't drive a `--disable-auth` server: it validates the session via `POST /api/v2/auth/whoAmI` before every operation (`leap auth login -k`, `projects create`, `push --eval`) and aborts with `Current authentication is invalid or expired` when no token resolves.

node-server now supports an explicit **`DISABLE_AUTH`** flag that short-circuits auth to a default admin user — [tensorleap/node-server#1723](https://github.com/tensorleap/node-server/pull/1723). This PR wires the existing installer flag to turn it on.

## What

- `pkg/helm/utils.go` — add `ServerHelmValuesParams.DisableAuth`; emit it as the `tensorleap-node-server.disableAuth` helm value.
- `pkg/server/installation_params.go` — set `DisableAuth: params.DisabledAuth` (the `--disable-auth` flag) alongside the existing `KeycloakEnabled: !DisabledAuth`.
- node-server subchart — `disableAuth: false` default in `values.yaml`, rendered as `DISABLE_AUTH` in the env configmap (mirrors `ENABLE_KEYCLOAK_AUTH`).
- `pkg/helm/utils_test.go` — assert the new value in the expected chart values.

Net effect: `leap server install --disable-auth` ⇒ `DISABLE_AUTH=true` on the node-server container ⇒ token-less CLI works, unblocking the leap-runner on-prem CI workflow ([tensorleap/leap-runner#6](https://github.com/tensorleap/leap-runner/pull/6)).

## Testing

- `go build ./...` — clean.
- `go test ./pkg/helm/... ./pkg/server/...` — pass.

## Merge order

Land [tensorleap/node-server#1723](https://github.com/tensorleap/node-server/pull/1723) (and ship a node-server image that reads `DISABLE_AUTH`) before/with this, since this flag only has an effect once node-server honors it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)