### PR TITLE
Wire per-job shared volume and blob-mode flags into engine chart

### DIFF
--- a/charts/tensorleap/charts/engine/templates/engine-cm.yaml
+++ b/charts/tensorleap/charts/engine/templates/engine-cm.yaml
@@ -46,5 +46,9 @@ data:
   JOB_SHARED_MAX_CONCURRENT_JOBS: "{{ .Values.job_shared_max_concurrent_jobs }}"
   JOB_SHARED_DISK_FRACTION: "{{ .Values.job_shared_disk_fraction }}"
   JOB_SHARED_DISK_MIN_FREE_GB: "{{ .Values.job_shared_disk_min_free_gb }}"
+  # Static per-job Redis sizing in blob mode (cluster default; a per-job pod_memory_override
+  # written via node-server's engine-redis-settings still takes precedence).
+  REDIS_BLOB_POD_GB: "{{ .Values.redis_blob_pod_gb }}"
+  REDIS_BLOB_MAXMEMORY_MB: "{{ .Values.redis_blob_maxmemory_mb }}"
 
 

--- a/charts/tensorleap/charts/engine/templates/engine-cm.yaml
+++ b/charts/tensorleap/charts/engine/templates/engine-cm.yaml
@@ -35,5 +35,8 @@ data:
   GENERIC_CALCULATOR_ENTRY_POINT: {{ .Values.entry_point }}
   GENERIC_ACTIVATE_NFS: "{{ .Values.metrics_activate_nfs }}"
   GENERIC_HOST_PATH: {{ .Values.localDataDirectories | join ":" }}
+  # Hybrid Redis->storage migration: redis (default) keeps payloads in Redis;
+  # blob moves payloads to the per-job shared volume, Redis carries references.
+  PAYLOAD_STORE: "{{ .Values.payload_store }}"
 
 

--- a/charts/tensorleap/charts/engine/templates/engine-cm.yaml
+++ b/charts/tensorleap/charts/engine/templates/engine-cm.yaml
@@ -38,5 +38,13 @@ data:
   # Hybrid Redis->storage migration: redis (default) keeps payloads in Redis;
   # blob moves payloads to the per-job shared volume, Redis carries references.
   PAYLOAD_STORE: "{{ .Values.payload_store }}"
+  # Phase 5 (blob mode only) capacity tuning. The per-queue length-cap budget is
+  # disk-bound: per_queue_gb = free_disk x fraction / max_concurrent_jobs / 4 (heavy queues).
+  # Raise max_concurrent_jobs on bigger nodes that run more jobs at once. min_free_gb is the
+  # shared-volume disk-free guard floor (the hard ceiling that replaces Redis noeviction OOM).
+  # All have in-code defaults; set here only to tune.
+  JOB_SHARED_MAX_CONCURRENT_JOBS: "{{ .Values.job_shared_max_concurrent_jobs }}"
+  JOB_SHARED_DISK_FRACTION: "{{ .Values.job_shared_disk_fraction }}"
+  JOB_SHARED_DISK_MIN_FREE_GB: "{{ .Values.job_shared_disk_min_free_gb }}"
 
 

--- a/charts/tensorleap/charts/engine/templates/engine-job-template-cm.yaml
+++ b/charts/tensorleap/charts/engine/templates/engine-job-template-cm.yaml
@@ -56,6 +56,9 @@ data:
                   mountPath: /usr/minio
                 - name: shared-logs
                   mountPath: /shared/logs
+                # Phase 1 (Redis->storage migration): per-job shared dir, k3d single-node hostPath
+                - name: job-shared
+                  mountPath: /job-shared
 {{- range .Values.additional_pvcs }}
                 - name: {{ .name  }}-vol
                   mountPath: {{ .mountPath }}
@@ -74,6 +77,13 @@ data:
                 claimName: tensorleap-minio
             - name: shared-logs
               emptyDir: {}  # Define shared-logs volume
+            # Phase 1 (Redis->storage migration): per-job shared dir.
+            # k3d is single-node, so this hostPath is effectively a ReadWriteMany
+            # volume shared by the main pod, generic-process and streaming-handler.
+            - name: job-shared
+              hostPath:
+                path: /var/lib/tensorleap/standalone/storage/job-shared
+                type: DirectoryOrCreate
 {{- range .Values.additional_pvcs }}
             - name: {{ .name  }}-vol
               persistentVolumeClaim:

--- a/charts/tensorleap/charts/engine/templates/engine-orchestrator.yaml
+++ b/charts/tensorleap/charts/engine/templates/engine-orchestrator.yaml
@@ -50,3 +50,13 @@ spec:
           envFrom:
             - configMapRef:
                 name: engine-cm
+          # Redis->storage migration: mount the per-job shared-volume base so the
+          # orchestrator can prune dirs leaked by hard-killed jobs (k3d single-node hostPath).
+          volumeMounts:
+            - name: job-shared
+              mountPath: /job-shared
+      volumes:
+        - name: job-shared
+          hostPath:
+            path: /var/lib/tensorleap/standalone/storage/job-shared
+            type: DirectoryOrCreate

--- a/charts/tensorleap/charts/engine/values.yaml
+++ b/charts/tensorleap/charts/engine/values.yaml
@@ -6,6 +6,12 @@ metrics_activate_nfs: false
 samples_generator_nfs: false
 # Hybrid Redis->storage data plane: redis (default) | blob (payloads on shared volume)
 payload_store: redis
+# Phase 5 blob-mode capacity tuning (only used when payload_store=blob). Disk-bound
+# queue-cap budget = free_disk x fraction / max_concurrent_jobs / 4. Raise concurrency on
+# bigger nodes. min_free_gb is the shared-volume disk-free guard floor.
+job_shared_max_concurrent_jobs: 2
+job_shared_disk_fraction: 0.6
+job_shared_disk_min_free_gb: 2
 env_name: "on-prem"
 dependencies_image_name: public.ecr.aws/tensorleap/pippin
 dependencies_image_tag: master-26a41e94

--- a/charts/tensorleap/charts/engine/values.yaml
+++ b/charts/tensorleap/charts/engine/values.yaml
@@ -1,4 +1,4 @@
-image_tag: feat-push-job-437ec670
+image_tag: add-per-job-shared-volume-98809e8e
 image_name: public.ecr.aws/tensorleap/engine
 redis_image: docker.io/library/redis:8.6-alpine
 entry_point: generic_processor

--- a/charts/tensorleap/charts/engine/values.yaml
+++ b/charts/tensorleap/charts/engine/values.yaml
@@ -1,4 +1,4 @@
-image_tag: add-per-job-shared-volume-98809e8e
+image_tag: master-20e386fa
 image_name: public.ecr.aws/tensorleap/engine
 redis_image: docker.io/library/redis:8.6-alpine
 entry_point: generic_processor

--- a/charts/tensorleap/charts/engine/values.yaml
+++ b/charts/tensorleap/charts/engine/values.yaml
@@ -12,6 +12,9 @@ payload_store: redis
 job_shared_max_concurrent_jobs: 2
 job_shared_disk_fraction: 0.6
 job_shared_disk_min_free_gb: 2
+# Static per-job Redis sizing in blob mode (default; per-job pod_memory_override still wins)
+redis_blob_pod_gb: 1
+redis_blob_maxmemory_mb: 768
 env_name: "on-prem"
 dependencies_image_name: public.ecr.aws/tensorleap/pippin
 dependencies_image_tag: master-26a41e94

--- a/charts/tensorleap/charts/engine/values.yaml
+++ b/charts/tensorleap/charts/engine/values.yaml
@@ -4,6 +4,8 @@ redis_image: docker.io/library/redis:8.6-alpine
 entry_point: generic_processor
 metrics_activate_nfs: false
 samples_generator_nfs: false
+# Hybrid Redis->storage data plane: redis (default) | blob (payloads on shared volume)
+payload_store: redis
 env_name: "on-prem"
 dependencies_image_name: public.ecr.aws/tensorleap/pippin
 dependencies_image_tag: master-26a41e94


### PR DESCRIPTION
Helm side of the hybrid Redis->storage data plane (pairs with engine PR tensorleap/engine#2332).

- Mount the per-job shared volume (k3d single-node hostPath) into the engine job pod and the orchestrator — the orchestrator uses it to prune orphan per-job dirs left by hard-killed jobs.
- Add `PAYLOAD_STORE` to engine-cm (default `redis`; `blob` offloads heavy queue payloads to the volume and Redis carries slim references).
- Add Phase 5 blob-mode tunables: `job_shared_max_concurrent_jobs`, `job_shared_disk_fraction`, `job_shared_disk_min_free_gb` (used only when `payload_store=blob`).

Defaults preserve current behavior (`payload_store=redis`). On-prem chart only; cloud (`engine/helm-chart`, EFS) is a follow-up.