### PR TITLE
Add CPU resource request to elasticsearch pod

### DIFF
--- a/charts/tensorleap/templates/elasticsearch.yaml
+++ b/charts/tensorleap/templates/elasticsearch.yaml
@@ -54,6 +54,7 @@ spec:
               resources:
                 requests:
                   memory: "6Gi"
+                  cpu: "1"
                 limits:
                   memory: "6Gi"
           initContainers:

--- a/charts/tensorleap/templates/elasticsearch.yaml
+++ b/charts/tensorleap/templates/elasticsearch.yaml
@@ -54,7 +54,7 @@ spec:
               resources:
                 requests:
                   memory: "6Gi"
-                  cpu: "1"
+                  cpu: "500m"
                 limits:
                   memory: "6Gi"
           initContainers:


### PR DESCRIPTION
The Elasticsearch pod declared a memory request/limit but no CPU request, so the scheduler had no guaranteed CPU floor for it. Add a 1-core CPU request under `resources.requests`.

No CPU limit is set, to avoid throttling a latency-sensitive workload. Verified the chart still renders with `helm template`.

Fixes [EN-2222](https://tensorleap.atlassian.net/browse/EN-2222).

[EN-2222]: https://tensorleap.atlassian.net/browse/EN-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ