### PR TITLE
upgrade: always use latest version (skip the stay-on-current prompt)

### DIFF
--- a/cmd/server/install.go
+++ b/cmd/server/install.go
@@ -87,7 +87,7 @@ func RunInstallCmd(cmd *cobra.Command, flags *InstallFlags) (*server.Installatio
 		return nil, err
 	}
 
-	mnf, isAirgap, infraChart, serverChart, err := server.InitInstallationProcess(&flags.InstallationSourceFlags, previousMnf)
+	mnf, isAirgap, infraChart, serverChart, err := server.InitInstallationProcess(&flags.InstallationSourceFlags, previousMnf, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/server/reinstall.go
+++ b/cmd/server/reinstall.go
@@ -68,7 +68,7 @@ func RunReinstallCmd(cmd *cobra.Command, flags *ReinstallFlags, isAlreadyReinsta
 		return nil, err
 	}
 
-	mnf, isAirgap, infraChart, serverChart, err := server.InitInstallationProcess(&flags.InstallationSourceFlags, previousMnf)
+	mnf, isAirgap, infraChart, serverChart, err := server.InitInstallationProcess(&flags.InstallationSourceFlags, previousMnf, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/server/upgrade.go
+++ b/cmd/server/upgrade.go
@@ -75,7 +75,9 @@ func RunUpgradeCmd(cmd *cobra.Command, flags *UpgradeFlags) (*server.Installatio
 		return nil, err
 	}
 
-	mnf, isAirgap, infraChart, serverChart, err := server.InitInstallationProcess(&flags.InstallationSourceFlags, previousMnf)
+	// upgrade always moves to the latest version (honoring an explicit
+	// --tag if given); never prompt to stay on the current version.
+	mnf, isAirgap, infraChart, serverChart, err := server.InitInstallationProcess(&flags.InstallationSourceFlags, previousMnf, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -22,7 +22,12 @@ const (
 	KUBE_NAMESPACE = "tensorleap"
 )
 
-func InitInstallationProcess(flags *InstallationSourceFlags, previousMnf *manifest.InstallationManifest) (mnf *manifest.InstallationManifest, isAirGap bool, infraHelmChart, serverHelmChart *chart.Chart, err error) {
+// InitInstallationProcess resolves the manifest (tag/local/airgap) and loads
+// the helm charts for it. forceLatestVersion, set by `upgrade`, skips the
+// "use latest version?" prompt and always resolves to the latest tag (unless
+// the caller passed an explicit --tag) — upgrade should never offer to stay
+// on the current version. install/reinstall pass false to keep the prompt.
+func InitInstallationProcess(flags *InstallationSourceFlags, previousMnf *manifest.InstallationManifest, forceLatestVersion bool) (mnf *manifest.InstallationManifest, isAirGap bool, infraHelmChart, serverHelmChart *chart.Chart, err error) {
 	isAirGap = flags.IsAirGap()
 	if isAirGap {
 		log.DisableReporting()
@@ -50,7 +55,9 @@ func InitInstallationProcess(flags *InstallationSourceFlags, previousMnf *manife
 			mnf, err = manifest.GenerateManifestFromLocal(fileGetter, localDir)
 		} else {
 			tag := flags.Tag
-			if previousMnf != nil && tag == "" && previousMnf.Tag != "" {
+			// On upgrade (forceLatestVersion) we never offer to keep the
+			// current version — leaving tag == "" resolves to latest below.
+			if !forceLatestVersion && previousMnf != nil && tag == "" && previousMnf.Tag != "" {
 
 				isInstallLatestVersion, err := AskUserForIsUseLatestVersion(previousMnf.Tag)
 				if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 
 // When upgrading major number(the middle digit) it will require reinstall
 
-const Version = "v0.10.5"
+const Version = "v0.10.6"
 
 func IsMinorVersionSmaller(currentVersion, comperedVersion string) bool {
 


### PR DESCRIPTION
## Summary
`leap server upgrade` shared the manifest-resolution path (`InitInstallationProcess`) with install/reinstall. That path prompts:

> Do you want to use latest version (latest: X, current: Y)?

whenever there's a previous install and no explicit `--tag`. The prompt **defaulted to `false`**, so hitting Enter during an *upgrade* kept the current version — the opposite of what `upgrade` is supposed to do.

This makes `upgrade` always resolve to the latest manifest, without prompting.

## Change
- `pkg/server/utils.go` — `InitInstallationProcess` takes a new `forceLatestVersion bool`. When true, it skips the `AskUserForIsUseLatestVersion` prompt and leaves `tag == ""`, which resolves to the latest manifest via `GetByTag("")`. An explicit `--tag` is still honored (it sets `tag` before the prompt block).
- `cmd/server/upgrade.go` — passes `true`.
- `cmd/server/install.go`, `cmd/server/reinstall.go` — pass `false`, preserving their existing interactive prompt.

## Behavior
| Command | `--tag X` | No `--tag`, previous install exists |
|---|---|---|
| `upgrade` | uses X | **uses latest (no prompt)** ← changed |
| `install` | uses X | prompts (unchanged) |
| `reinstall` | uses X | prompts (unchanged) |

`LoadManifestOnly` (used only by `install`, never `upgrade`) is untouched, so install's pre-check prompt is unchanged.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./pkg/server/... ./cmd/server/...` clean
- [ ] `leap server upgrade` with a previous install and no `--tag` → goes straight to latest, no version prompt
- [ ] `leap server upgrade --tag <older>` → still installs that explicit tag
- [ ] `leap server install` (re-run) → still prompts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)