### PR TITLE
Fix airgap install deadlock: pre-load k3s system images into containerd

### DIFF
--- a/cmd/server/install.go
+++ b/cmd/server/install.go
@@ -66,6 +66,9 @@ func RunInstallCmd(cmd *cobra.Command, flags *InstallFlags) (*server.Installatio
 	}
 
 	isAirgap := flags.IsAirGap()
+	if isAirgap {
+		log.DisableReporting()
+	}
 
 	installationParams, err := server.InitInstallationParamsFromFlags(&flags.InstallFlags, isAirgap)
 	if err != nil {

--- a/cmd/server/reinstall.go
+++ b/cmd/server/reinstall.go
@@ -62,6 +62,9 @@ func RunReinstallCmd(cmd *cobra.Command, flags *ReinstallFlags, isAlreadyReinsta
 	}
 
 	isAirgap := flags.IsAirGap()
+	if isAirgap {
+		log.DisableReporting()
+	}
 
 	installationParams, err := server.InitInstallationParamsFromFlags(&flags.InstallFlags, isAirgap)
 	if err != nil {

--- a/pkg/server/install.go
+++ b/pkg/server/install.go
@@ -101,14 +101,23 @@ func airgapBootstrap(ctx context.Context, mnf *manifest.InstallationManifest, in
 	return nil
 }
 
-// getBootstrapImages returns the minimal set of images that must be imported
+// getBootstrapImages returns the set of images that must be imported directly
 // into containerd via k3d image-import before any in-cluster registry exists.
-// k3s system images (coredns, klipper-lb, etc.) are embedded in the k3s binary
-// and auto-loaded on startup, so only the Zot registry image is needed here.
+// The cluster registries.yaml routes all docker.io (and other) pulls through
+// the local Zot registry at 127.0.0.1:5000.  Zot runs as a k8s pod, and k8s
+// needs the pause image to create pod sandboxes — but it tries to pull that
+// image through Zot, which isn't up yet.  Breaking the deadlock requires that
+// the k3s system images (including rancher/mirrored-pause) are pre-loaded
+// directly into containerd before we wait for Zot to become ready.
 func getBootstrapImages(mnf *manifest.InstallationManifest, useGpu bool) []string {
 	images := []string{}
 	if mnf.Images.Zot != "" {
 		images = append(images, mnf.Images.Zot)
+	}
+	if useGpu {
+		images = append(images, mnf.Images.K3sGpuImages...)
+	} else {
+		images = append(images, mnf.Images.K3sImages...)
 	}
 	return images
 }


### PR DESCRIPTION
## Summary

- `leap server install --airgap` was stuck forever — all pods stayed in `ContainerCreating`
- Root cause: deadlock between Zot (the in-cluster registry) and the k3s pause image

## Root cause

The cluster's `registries.yaml` routes **all** image pulls (including `docker.io`) through the local Zot registry at `127.0.0.1:5000`. Zot runs as a Kubernetes pod, which requires a pod sandbox, which requires `docker.io/rancher/mirrored-pause:3.6`. k8s tries to pull that image from Zot — but Zot isn't running yet.

Classic deadlock: Zot needs the pause image → pause image needs Zot.

The `getBootstrapImages` function had an incorrect comment claiming k3s system images are "embedded in the k3s binary". They are not — at least not in a way that bypasses the mirror registry config.

## Fix

Add the k3s system images (`K3sImages` / `K3sGpuImages`, which include `rancher/mirrored-pause:3.6`) to the set of images imported directly into containerd via `k3d image-import` during airgap bootstrap, before the infra chart is installed and before `WaitForRegistry` blocks.

## Test plan

- [ ] Run `leap server install --airgap pack.tar` on a machine with no internet and verify it completes successfully
- [ ] Confirm pods progress past `ContainerCreating` after bootstrap
- [ ] Verify GPU path (`--gpu`) is also covered (uses `K3sGpuImages`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)