### PR TITLE
Fix airgap bootstrap deadlock (ECK operator + pause image)

### DIFF
--- a/pkg/helm/install.go
+++ b/pkg/helm/install.go
@@ -14,15 +14,36 @@ func InstallChart(
 	chart *chart.Chart,
 	values Record,
 ) error {
+	return installChart(config, releaseName, chart, values, true, 4*time.Hour)
+}
 
+// InstallChartNoWait submits the chart manifests and returns immediately without
+// waiting for pods to become ready. Use when readiness is monitored separately.
+func InstallChartNoWait(
+	config *HelmConfig,
+	releaseName string,
+	chart *chart.Chart,
+	values Record,
+) error {
+	return installChart(config, releaseName, chart, values, false, 5*time.Minute)
+}
+
+func installChart(
+	config *HelmConfig,
+	releaseName string,
+	chart *chart.Chart,
+	values Record,
+	wait bool,
+	timeout time.Duration,
+) error {
 	log.Printf("Installing helm chart %s (will take few minutes)", releaseName)
 
 	client := action.NewInstall(config.ActionConfig)
 	client.Namespace = config.Namespace
 	client.CreateNamespace = true
-	client.Wait = true
+	client.Wait = wait
 	client.ReleaseName = releaseName
-	client.Timeout = 4 * time.Hour
+	client.Timeout = timeout
 
 	_, err := client.RunWithContext(config.Context, chart, values)
 	if err != nil {

--- a/pkg/server/install.go
+++ b/pkg/server/install.go
@@ -146,12 +146,11 @@ func installInfraChart(ctx context.Context, mnf *manifest.InstallationManifest, 
 		return err
 	}
 	if !isInfraReleaseExisted {
-		var syncRegistries []helm.ZotSyncRegistry
-		if installationParams.IsAirgap {
-			syncRegistries = k3d.BuildZotSyncRegistries(mnf)
-		}
-		infraValues := helm.CreateInfraChartValues(installationParams.GetInfraHelmValuesParams(syncRegistries, mnf.Images.Zot))
-		if err := helm.InstallChart(helmConfig, infraChartMeta.ReleaseName, infraChart, infraValues); err != nil {
+		infraValues := helm.CreateInfraChartValues(installationParams.GetInfraHelmValuesParams(nil, mnf.Images.Zot))
+		// Don't wait: ECK operator (also in this chart) needs its image pulled from
+		// Zot, which isn't ready yet. WaitForRegistry polls for Zot specifically;
+		// Phase 2 pushes all images so ECK operator can pull on retry.
+		if err := helm.InstallChartNoWait(helmConfig, infraChartMeta.ReleaseName, infraChart, infraValues); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes two sequential deadlocks in the airgap install bootstrap phase:

**Deadlock 1** (commit `d019cda0`): k3s routes all image pulls through the local Zot registry. Zot runs as a k8s pod, but k8s needs the `rancher/mirrored-pause` image to create pod sandboxes — which it tried to pull through Zot, which wasn't up yet. Fixed by pre-importing k3s system images directly into containerd before installing the infra chart.

**Deadlock 2** (this PR's new commit): The infra chart deploys both Zot and the ECK operator. `installInfraChart` used `client.Wait=true`, blocking until all infra pods were ready — including ECK operator. But ECK operator's image is in `serverImages`, not pre-loaded into containerd, and Phase 2 (push images to Zot) runs *after* bootstrap. ECK operator sat in `ImagePullBackOff` indefinitely.

**Fix**: Switch `installInfraChart` to `InstallChartNoWait` — submits manifests and returns immediately. `WaitForRegistry` then polls specifically for Zot (starts fast, image pre-loaded). Phase 2 pushes all images to Zot. By the time the server chart installs, ECK operator has its image and is running.

## Test plan

- [x] Full local airgap install tested end-to-end with `./leap-linux install --airgap pack.tar`
- [x] Bootstrap phase completes without hanging: k3s images imported → infra chart submitted → Zot ready → 28 images pushed → server chart installed
- [x] `Successfully completed installation` — Tensorleap accessible at `http://localhost:4589`

🤖 Generated with [Claude Code](https://claude.com/claude-code)