### PR TITLE
Propagate proxy env to engine PUSH jobs (pippin builder)

### DIFF
--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.6.34
+version: 1.6.35
 dependencies:
   - name: ingress-nginx
     version: 4.10.0

--- a/charts/tensorleap/charts/engine/Chart.yaml
+++ b/charts/tensorleap/charts/engine/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-engine
 type: application
-version: 1.0.614
+version: 1.0.615

--- a/charts/tensorleap/charts/engine/templates/engine-job-template-cm.yaml
+++ b/charts/tensorleap/charts/engine/templates/engine-job-template-cm.yaml
@@ -39,6 +39,24 @@ data:
                   value: /shared/logs
                 - name: IS_K3D
                   value: "true"
+              {{- if .Values.http_proxy }}
+                - name: HTTP_PROXY
+                  value: {{ .Values.http_proxy | quote }}
+                - name: http_proxy
+                  value: {{ .Values.http_proxy | quote }}
+              {{- end }}
+              {{- if .Values.https_proxy }}
+                - name: HTTPS_PROXY
+                  value: {{ .Values.https_proxy | quote }}
+                - name: https_proxy
+                  value: {{ .Values.https_proxy | quote }}
+              {{- end }}
+              {{- if .Values.no_proxy }}
+                - name: NO_PROXY
+                  value: {{ .Values.no_proxy | quote }}
+                - name: no_proxy
+                  value: {{ .Values.no_proxy | quote }}
+              {{- end }}
               volumeMounts:
                 - name: shared-logs
                   mountPath: /shared/logs

--- a/charts/tensorleap/charts/engine/values.yaml
+++ b/charts/tensorleap/charts/engine/values.yaml
@@ -11,6 +11,12 @@ target_repo: tensorleap-registry:5000
 generic_calculator_image: "public.ecr.aws/tensorleap/engine-generic"
 generic_py_ver: py38 #select from: py38, py39, py310
 
+# Outbound proxy for engine PUSH jobs (the pippin image-dependencies-builder dind).
+# Set by the installer from its own HTTP(S)_PROXY/NO_PROXY env; empty = no proxy.
+http_proxy: ""
+https_proxy: ""
+no_proxy: ""
+
 localDataDirectories: []
 gpu: false
 gpuTolerations: []

--- a/pkg/helm/utils.go
+++ b/pkg/helm/utils.go
@@ -37,6 +37,7 @@ type ServerHelmValuesParams struct {
 	Tls                    TLSParams         `json:"tls"`
 	HostName               string            `json:"hostname"`
 	DatadogEnv             map[string]string `json:"datadogEnv"`
+	ProxyEnv               map[string]string `json:"proxyEnv"`
 	KeycloakEnabled        bool              `json:"keycloakEnabled"`
 	DisableAuth            bool              `json:"disableAuth"`
 	InstalledServerVersion string            `json:"installedServerVersion"`
@@ -255,6 +256,9 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 		"tensorleap-engine": Record{
 			"gpu":                  params.Gpu,
 			"localDataDirectories": params.LocalDataDirectories,
+			"http_proxy":           params.ProxyEnv["http_proxy"],
+			"https_proxy":          params.ProxyEnv["https_proxy"],
+			"no_proxy":             params.ProxyEnv["no_proxy"],
 		},
 		"tensorleap-node-server": Record{
 			"enableKeycloak":         params.KeycloakEnabled,

--- a/pkg/helm/utils_test.go
+++ b/pkg/helm/utils_test.go
@@ -27,6 +27,9 @@ func TestCreateTensorleapChartValues(t *testing.T) {
 			"tensorleap-engine": Record{
 				"gpu":                  params.Gpu,
 				"localDataDirectories": params.LocalDataDirectories,
+				"http_proxy":           "",
+				"https_proxy":          "",
+				"no_proxy":             "",
 			},
 			"tensorleap-node-server": Record{
 				"enableKeycloak":         params.KeycloakEnabled,

--- a/pkg/server/installation_params.go
+++ b/pkg/server/installation_params.go
@@ -838,6 +838,8 @@ func (params *InstallationParams) GetServerHelmValuesParams(versionTag string) *
 
 	datadogEnvs := params.GetDatadogEnvs()
 
+	proxyEnvs := params.GetEngineProxyEnv()
+
 	localBucketPath := path.Join(local.GetServerDataDir(), local.STORAGE_DIR_NAME, "minio", "session")
 
 	return &helm.ServerHelmValuesParams{
@@ -850,6 +852,7 @@ func (params *InstallationParams) GetServerHelmValuesParams(versionTag string) *
 		ProxyUrl:               params.ProxyUrl,
 		Tls:                    *tlsParams,
 		DatadogEnv:             datadogEnvs,
+		ProxyEnv:               proxyEnvs,
 		KeycloakEnabled:        !params.DisabledAuth,
 		DisableAuth:            params.DisabledAuth,
 		InstalledServerVersion: versionTag,
@@ -874,6 +877,48 @@ func (params *InstallationParams) GetDatadogEnvs() map[string]string {
 	}
 
 	return data
+}
+
+// engineJobNoProxyEntries are appended to the user's NO_PROXY so that engine PUSH
+// jobs reach in-cluster services (Zot registry, MinIO, k8s API/DNS) directly
+// instead of routing them through the corporate proxy.
+var engineJobNoProxyEntries = []string{
+	"tensorleap-registry",
+	"tensorleap-minio",
+	"localhost",
+	"127.0.0.1",
+	".svc",
+	".svc.cluster.local",
+	".cluster.local",
+	"10.42.0.0/16",
+	"10.43.0.0/16",
+}
+
+// GetEngineProxyEnv returns the outbound-proxy env to inject into engine PUSH jobs
+// (notably the pippin image-dependencies-builder dind, which runs its own daemon and
+// does not inherit the node's containerd proxy/mirror config). Values are captured
+// from the installer's own environment; returns nil when no proxy is configured.
+func (params *InstallationParams) GetEngineProxyEnv() map[string]string {
+	httpProxy := lookupFirstEnv("HTTP_PROXY", "http_proxy")
+	httpsProxy := lookupFirstEnv("HTTPS_PROXY", "https_proxy")
+	if httpProxy == "" && httpsProxy == "" {
+		return nil
+	}
+	noProxy := lookupFirstEnv("NO_PROXY", "no_proxy")
+	return map[string]string{
+		"http_proxy":  httpProxy,
+		"https_proxy": httpsProxy,
+		"no_proxy":    k3d.AddToNoProxy(noProxy, engineJobNoProxyEntries),
+	}
+}
+
+func lookupFirstEnv(keys ...string) string {
+	for _, key := range keys {
+		if value, ok := os.LookupEnv(key); ok && value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (params *InstallationParams) GetInfraHelmValuesParams(syncRegistries []helm.ZotSyncRegistry, registryImage string) *helm.InfraHelmValuesParams {

--- a/pkg/server/installation_params_test.go
+++ b/pkg/server/installation_params_test.go
@@ -91,3 +91,34 @@ func TestGetServerHelmValuesParams(t *testing.T) {
 		assert.False(t, helmParams.KeycloakEnabled, "Keycloak should be disabled when DisabledAuth is true")
 	})
 }
+
+func TestGetEngineProxyEnv(t *testing.T) {
+	params := &InstallationParams{}
+
+	t.Run("returns nil when no proxy is set", func(t *testing.T) {
+		t.Setenv("HTTP_PROXY", "")
+		t.Setenv("http_proxy", "")
+		t.Setenv("HTTPS_PROXY", "")
+		t.Setenv("https_proxy", "")
+		assert.Nil(t, params.GetEngineProxyEnv())
+	})
+
+	t.Run("captures proxy and augments no_proxy with in-cluster entries", func(t *testing.T) {
+		t.Setenv("HTTPS_PROXY", "http://proxy:3128")
+		t.Setenv("NO_PROXY", ".renault.fr")
+
+		env := params.GetEngineProxyEnv()
+		assert.Equal(t, "http://proxy:3128", env["https_proxy"])
+		assert.Contains(t, env["no_proxy"], ".renault.fr")
+		assert.Contains(t, env["no_proxy"], "tensorleap-registry")
+		assert.Contains(t, env["no_proxy"], "tensorleap-minio")
+		assert.Contains(t, env["no_proxy"], "10.43.0.0/16")
+	})
+
+	t.Run("prefers uppercase but falls back to lowercase", func(t *testing.T) {
+		t.Setenv("HTTP_PROXY", "")
+		t.Setenv("http_proxy", "http://lower:3128")
+		env := params.GetEngineProxyEnv()
+		assert.Equal(t, "http://lower:3128", env["http_proxy"])
+	})
+}


### PR DESCRIPTION
## Problem

On a corporate-proxy / k3d install, PUSH jobs fail in the `image-dependencies-builder` (pippin) init container:

```
Get "https://public.ecr.aws/v2/": dial tcp: lookup public.ecr.aws on 10.43.0.10:53: no such host
```

pippin runs its **own docker-in-docker daemon** to build the per-project `engine-generic` image. That daemon does **not** inherit the k3d node's containerd registry-mirror or proxy config (it's a separate daemon inside the pod), and it resolves via cluster DNS — so behind a proxy it can neither resolve nor reach `public.ecr.aws`.

## Fix

Capture `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` from the installer's own environment and inject them into the engine job template's init container, so pippin's dind egresses through the corporate proxy (which also resolves the external name, fixing the DNS error too).

- `engine-job-template-cm.yaml`: render `HTTP(S)_PROXY` / `NO_PROXY` (upper + lower case) on the init container, **only when set**.
- `engine/values.yaml`: new `http_proxy` / `https_proxy` / `no_proxy` (default `""` → no-op).
- `pkg/helm/utils.go`: `ProxyEnv` on `ServerHelmValuesParams`, wired into the `tensorleap-engine` values.
- `pkg/server/installation_params.go`: `GetEngineProxyEnv()` captures proxy from env (uppercase-first, lowercase fallback; `nil` when unset) and **augments `NO_PROXY`** with in-cluster targets (`tensorleap-registry`, `tensorleap-minio`, `localhost`, `.svc`, `.cluster.local`, `10.42/10.43` CIDRs) so the local Zot push, MinIO and DNS bypass the proxy.

## Why it's safe with node-server

node-server loads this template and mutates the init-container env via `setEnvParams`, which **merges by name** (update-or-append) and never rebuilds/filters the array; it only sets `IMAGE_TAG`/`DEPENDENCY_URL`/`BASE_IMAGE` and appends `PIP_INDEX_URL`/`PIP_EXTRA_INDEX_URL`. None collide with the proxy keys, so the chart-declared proxy vars are preserved.

## Validation

- `go build ./...`, `go vet`, `gofmt`, `go test ./pkg/server ./pkg/helm` — pass (golden updated; new `TestGetEngineProxyEnv`).
- `make build-helm`; `helm template` — default render has **0** proxy env lines; with proxy values set the env block renders on the init container. `make validate-images` — 20 images valid.
- Patch version bumps (`tensorleap` 1.6.28→1.6.29, `tensorleap-engine` 1.0.610→1.0.611) — no cluster reinstall, applies on upgrade.

## Rollout

Operator upgrades with the **container-reachable** proxy exported (e.g. `cosmos-vip…:3128`, not `localhost:911`); new PUSH jobs then pull `engine-generic` through the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)