### PR TITLE
Propagate proxy env to engine-generic workers via engine-cm

### DIFF
--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.6.35
+version: 1.6.36
 dependencies:
   - name: ingress-nginx
     version: 4.10.0

--- a/charts/tensorleap/charts/engine/Chart.yaml
+++ b/charts/tensorleap/charts/engine/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-engine
 type: application
-version: 1.0.615
+version: 1.0.616

--- a/charts/tensorleap/charts/engine/templates/engine-cm.yaml
+++ b/charts/tensorleap/charts/engine/templates/engine-cm.yaml
@@ -35,5 +35,17 @@ data:
   GENERIC_CALCULATOR_ENTRY_POINT: {{ .Values.entry_point }}
   GENERIC_ACTIVATE_NFS: "{{ .Values.metrics_activate_nfs }}"
   GENERIC_HOST_PATH: {{ .Values.localDataDirectories | join ":" }}
+{{- if .Values.http_proxy }}
+  HTTP_PROXY: {{ .Values.http_proxy | quote }}
+  http_proxy: {{ .Values.http_proxy | quote }}
+{{- end }}
+{{- if .Values.https_proxy }}
+  HTTPS_PROXY: {{ .Values.https_proxy | quote }}
+  https_proxy: {{ .Values.https_proxy | quote }}
+{{- end }}
+{{- if .Values.no_proxy }}
+  NO_PROXY: {{ .Values.no_proxy | quote }}
+  no_proxy: {{ .Values.no_proxy | quote }}
+{{- end }}
 
 


### PR DESCRIPTION
Follow-up to #392 (which covered the pippin push-job init container). This extends proxy propagation to the **engine-generic worker pods** and the rest of the engine workloads.

## Why

The engine process spawns engine-generic worker pods itself (as a Deployment, `create_namespaced_deployment` in the engine repo's `deployment_manager.py`), and those pods source their env from the **`engine-cm` ConfigMap via `envFrom`** — *not* from the engine container's own env. So putting proxy vars on the engine container would not reach the workers; the correct single source is `engine-cm`.

## What

Add `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (upper + lower case) to `engine-cm`, rendered only when set. One edit reaches every `envFrom: engine-cm` consumer:
- engine main job container
- **engine-generic worker Deployment** (created by engine code)
- engine-orchestrator
- copy-deps post-deploy job

In-pod `os.fork()` children inherit the pod env automatically. Reuses the existing engine proxy values (`GetEngineProxyEnv` → `.Values.http_proxy/https_proxy/no_proxy`) introduced in #392 — **no installer change and no engine-code change** (the worker Deployment references `engine-cm` by name, so it picks up the keys at runtime). The pippin init container keeps its explicit proxy env (it has no `envFrom`).

`NO_PROXY` is already augmented with in-cluster targets (zot registry, minio, `.svc`, `.cluster.local`, `10.42/10.43` CIDRs) so workers' in-cluster traffic bypasses the proxy.

## Validation

- `helm template`: `engine-cm` has **0** proxy keys by default; all **6** keys render (inside the `engine-cm` ConfigMap) when proxy values are set.
- `go build`, `gofmt`, and full `go test ./...` all pass.
- Chart bumps: `tensorleap` 1.6.35→1.6.36, `tensorleap-engine` 1.0.615→1.0.616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)