### PR TITLE
Create shared dirs world-writable so non-sudo users can reinstall

### DIFF
--- a/pkg/local/files.go
+++ b/pkg/local/files.go
@@ -38,12 +38,24 @@ func EnsureDirExists(path string) error {
 		return nil
 	}
 
+	useSudo := !status.CanCreateOnParentDirectory
 	mkDirArgs := []string{"mkdir", "-p", path}
-	if !status.CanCreateOnParentDirectory {
+	if useSudo {
 		mkDirArgs = append([]string{"sudo"}, mkDirArgs...)
 	}
 	if err := RunCommand(mkDirArgs...); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)
+	}
+
+	// Make world-writable so a different (non-sudo) user can also use the dir.
+	// mkdir honors umask, so an explicit chmod is required. ponytail: 0777 by
+	// design — this tree is shared across local users on a single-node install.
+	chmodArgs := []string{"chmod", "777", path}
+	if useSudo {
+		chmodArgs = append([]string{"sudo"}, chmodArgs...)
+	}
+	if err := RunCommand(chmodArgs...); err != nil {
+		return fmt.Errorf("failed to set directory permissions: %v", err)
 	}
 
 	return nil

--- a/pkg/local/files.go
+++ b/pkg/local/files.go
@@ -38,27 +38,42 @@ func EnsureDirExists(path string) error {
 		return nil
 	}
 
-	useSudo := !status.CanCreateOnParentDirectory
-	mkDirArgs := []string{"mkdir", "-p", path}
-	if useSudo {
-		mkDirArgs = append([]string{"sudo"}, mkDirArgs...)
-	}
-	if err := RunCommand(mkDirArgs...); err != nil {
-		return fmt.Errorf("failed to create directory: %v", err)
+	createdWithSudo := false
+	if !status.Exists {
+		mkDirArgs := []string{"mkdir", "-p", path}
+		if !status.CanCreateOnParentDirectory {
+			createdWithSudo = true
+			mkDirArgs = append([]string{"sudo"}, mkDirArgs...)
+		}
+		if err := RunCommand(mkDirArgs...); err != nil {
+			return fmt.Errorf("failed to create directory: %v", err)
+		}
+	} else if isWorldWritable(path) {
+		// Already shared — nothing to do.
+		return nil
 	}
 
-	// Make world-writable so a different (non-sudo) user can also use the dir.
-	// mkdir honors umask, so an explicit chmod is required. ponytail: 0777 by
-	// design — this tree is shared across local users on a single-node install.
+	// Ensure the dir is world-writable so another local user (without sudo) can
+	// also use it. mkdir honors umask, and a dir left by a previous user may be
+	// 0755 — either way a second user can't write into it. chmod needs
+	// ownership or root, so use sudo when the dir isn't ours. A non-owner
+	// without sudo can't fix this (Unix rule) and gets a clear error; the perms
+	// must then be repaired once by the owner or an admin.
 	chmodArgs := []string{"chmod", "777", path}
-	if useSudo {
+	if createdWithSudo || !status.CanWrite {
 		chmodArgs = append([]string{"sudo"}, chmodArgs...)
 	}
 	if err := RunCommand(chmodArgs...); err != nil {
-		return fmt.Errorf("failed to set directory permissions: %v", err)
+		return fmt.Errorf("failed to set directory permissions on %s: %v", path, err)
 	}
 
 	return nil
+}
+
+// isWorldWritable reports whether path exists and has the other-write bit set.
+func isWorldWritable(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().Perm()&0002 != 0
 }
 
 // MoveOrCopyDirectory tries to rename the directory, on failure tries to copy

--- a/pkg/server/installation_params.go
+++ b/pkg/server/installation_params.go
@@ -655,7 +655,7 @@ func validateAndNormalizeDatasetVolumePath(path string) (string, error) {
 
 	isContainerAndHostIsTheSame := hostPath == containerPath
 
-	if err := os.MkdirAll(hostPath, 0777); err != nil {
+	if err := local.EnsureDirExists(hostPath); err != nil {
 		return "", fmt.Errorf("failed to create dataset volume directory: %v", err)
 	}
 	realDataPath, err := local.RealPath(hostPath)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 
 // When upgrading major number(the middle digit) it will require reinstall
 
-const Version = "v0.10.9"
+const Version = "v0.10.10"
 
 func IsMinorVersionSmaller(currentVersion, comperedVersion string) bool {
 


### PR DESCRIPTION
## What

Two dataset-volume-related changes on this branch:

1. **Local-directory autocomplete** for the dataset volume prompt & flags (existing commits).
2. **World-writable shared dirs** so a second, non-sudo user can run `reinstall`.

## The permission fix

Running `reinstall` as a different user without sudo failed twice:

```
ERRO failed to create dataset volume directory: mkdir /home/ec2-user/tensorleap: permission denied
ERRO open /var/lib/tensorleap/standalone/helm-cache/tensorleap/1.6.39.tgz: permission denied
```

Root cause is shared: dirs created by the first user were `0755`/owner-only, so a second user couldn't write into them. `mkdir` honors the umask, so passing `0777` still produced `0755`.

- `EnsureDirExists` now `chmod 777`s the dir after creating it (with the same sudo fallback used for `mkdir`).
- The dataset-volume dir now goes through `EnsureDirExists` instead of raw `os.MkdirAll`, giving it the sudo fallback + world-write treatment.

## Note

This fixes *future* installs. Dirs from an existing install keep their old perms — repair once with `sudo chmod -R 777 /var/lib/tensorleap/standalone` (and the dataset-volume path). A dataset volume pointing inside another user's home still can't be created without sudo; point it at a shared writable location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)