### PR TITLE
Reapply airgap BuildKit registry-DNS fix and force reinstall

### DIFF
--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.6.45
+version: 1.7.0
 dependencies:
   - name: ingress-nginx
     version: 4.10.0

--- a/charts/tensorleap/charts/engine/templates/buildkit-helper-override-cm.yaml
+++ b/charts/tensorleap/charts/engine/templates/buildkit-helper-override-cm.yaml
@@ -1,0 +1,290 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: buildkit-helper-override-cm
+{{- if .Values.global.target_namespace }}
+  namespace: {{ .Values.global.target_namespace }}
+{{- else if .Values.global.namespacedInstall }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+data:
+  buildkit_helper.py: |
+    # buildkit_helper.py — override for airgap/k3d: routes BuildKit registry
+    # operations to BUILDKIT_REGISTRY_HOST (127.0.0.1:<port>) instead of the
+    # k8s-internal "tensorleap-registry:5000" name, which is not resolvable
+    # from the host-Docker network namespace where BuildKit runs.
+    import logging
+    import os
+    import subprocess
+    import time
+    from typing import Optional, Tuple, List
+
+    logger = logging.getLogger(__name__)
+
+    BUILDER_NAME = "pippin-builder"
+    CACHE_TAG = "buildcache"
+    BUILDKITD_CONFIG_PATH = "/tmp/buildkitd.toml"
+
+    # When set, BuildKit push/pull targets use this address instead of target_repo.
+    # This allows BuildKit (running in host-Docker network) to reach Zot via the
+    # host-mapped port (e.g. 127.0.0.1:5699) while pod-level registry checks still
+    # use the k8s-DNS name (tensorleap-registry:5000).
+    BUILDKIT_REGISTRY_HOST = os.environ.get("BUILDKIT_REGISTRY_HOST", "")
+
+
+    class BuildKitError(Exception):
+        pass
+
+
+    def create_buildkitd_config(insecure_registries: List[str] = None) -> str:
+        config_content = ""
+        # When BUILDKIT_REGISTRY_HOST is set, mirror tensorleap-registry:5000
+        # to it so BuildKit (running in host-Docker network) can resolve the
+        # FROM image in the generated Dockerfile.  We must NOT emit a plain
+        # [registry."tensorleap-registry:5000"] block AND the mirror block — TOML
+        # forbids duplicate table headers, so we combine them into one entry.
+        mirror_registries = {"tensorleap-registry:5000"} if BUILDKIT_REGISTRY_HOST else set()
+        if insecure_registries:
+            for registry in insecure_registries:
+                if registry in mirror_registries:
+                    continue  # handled below with mirror config
+                config_content += f'''
+    [registry."{registry}"]
+      http = true
+      insecure = true
+    '''
+        if BUILDKIT_REGISTRY_HOST:
+            config_content += f'''
+    [registry."tensorleap-registry:5000"]
+      mirrors = ["{BUILDKIT_REGISTRY_HOST}"]
+      http = true
+      insecure = true
+    '''
+        with open(BUILDKITD_CONFIG_PATH, "w") as f:
+            f.write(config_content)
+        logger.debug(f"Created buildkitd config at {BUILDKITD_CONFIG_PATH}")
+        return BUILDKITD_CONFIG_PATH
+
+
+    def is_buildx_available() -> bool:
+        try:
+            result = subprocess.run(
+                ["docker", "buildx", "version"],
+                capture_output=True, text=True, timeout=10
+            )
+            return result.returncode == 0
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return False
+
+
+    def get_existing_builders() -> List[str]:
+        try:
+            result = subprocess.run(
+                ["docker", "buildx", "ls", "--format", "{{.Name}}"],
+                capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                return [n.strip() for n in result.stdout.strip().split("\n") if n.strip()]
+            return []
+        except subprocess.SubprocessError:
+            return []
+
+
+    def setup_buildx_builder(
+        builder_name: str = BUILDER_NAME,
+        insecure_registries: List[str] = None,
+        force_recreate: bool = False,
+    ) -> str:
+        if not is_buildx_available():
+            raise BuildKitError("docker buildx is not available.")
+
+        # Also mark BUILDKIT_REGISTRY_HOST as insecure so BuildKit can reach it.
+        all_insecure = list(insecure_registries or [])
+        if BUILDKIT_REGISTRY_HOST and BUILDKIT_REGISTRY_HOST not in all_insecure:
+            all_insecure.append(BUILDKIT_REGISTRY_HOST)
+        insecure_registries = all_insecure if all_insecure else None
+
+        existing_builders = get_existing_builders()
+
+        if force_recreate and builder_name in existing_builders:
+            logger.info(f"Force recreating builder: {builder_name}")
+            cleanup_builder(builder_name)
+            existing_builders = get_existing_builders()
+
+        if builder_name in existing_builders:
+            logger.info(f"Using existing buildx builder: {builder_name}")
+            try:
+                subprocess.run(
+                    ["docker", "buildx", "inspect", builder_name, "--bootstrap"],
+                    capture_output=True, text=True, timeout=60
+                )
+            except subprocess.SubprocessError as e:
+                logger.warning(f"Failed to bootstrap existing builder: {e}")
+            return builder_name
+
+        logger.info(f"Creating new buildx builder: {builder_name}")
+        config_path = None
+        if insecure_registries:
+            config_path = create_buildkitd_config(insecure_registries)
+            logger.info(f"Using buildkitd config with insecure registries: {insecure_registries}")
+
+        create_cmd = [
+            "docker", "buildx", "create",
+            "--name", builder_name,
+            "--driver", "docker-container",
+            "--driver-opt", "network=host",
+        ]
+        if config_path:
+            create_cmd.extend(["--config", config_path])
+        create_cmd.append("--bootstrap")
+
+        try:
+            result = subprocess.run(create_cmd, capture_output=True, text=True, timeout=120)
+            if result.returncode != 0:
+                raise BuildKitError(f"Failed to create builder: {result.stderr}")
+            logger.info(f"Successfully created buildx builder: {builder_name}")
+            return builder_name
+        except subprocess.TimeoutExpired:
+            raise BuildKitError("Timeout while creating buildx builder")
+        except subprocess.SubprocessError as e:
+            raise BuildKitError(f"Failed to create buildx builder: {e}")
+
+
+    def get_cache_refs(target_repo: str, is_k3d: bool) -> Tuple[str, str]:
+        if is_k3d:
+            buildkit_repo = BUILDKIT_REGISTRY_HOST if BUILDKIT_REGISTRY_HOST else target_repo
+            cache_ref = f"{buildkit_repo}/tensorleap/engine-generic:{CACHE_TAG}"
+        else:
+            cache_ref = f"{target_repo}:{CACHE_TAG}"
+        cache_from = f"type=registry,ref={cache_ref}"
+        cache_to = f"type=registry,ref={cache_ref},mode=max"
+        return cache_from, cache_to
+
+
+    def build_with_cache(
+        context_dir: str,
+        target_repo: str,
+        tag: str,
+        is_k3d: bool,
+        builder_name: str = BUILDER_NAME,
+        push: bool = True,
+        log_file_path: Optional[str] = None,
+    ) -> Tuple[bool, str, List[str]]:
+        cache_from, cache_to = get_cache_refs(target_repo, is_k3d)
+
+        if is_k3d:
+            buildkit_repo = BUILDKIT_REGISTRY_HOST if BUILDKIT_REGISTRY_HOST else target_repo
+            full_image_name = f"{buildkit_repo}/tensorleap/engine-generic:{tag}"
+        else:
+            full_image_name = f"{target_repo}:{tag}"
+
+        # When BUILDKIT_REGISTRY_HOST is set, rewrite the Dockerfile's FROM line
+        # to use the host-accessible address instead of the k8s-internal service
+        # name (tensorleap-registry:5000), which is unreachable from the host-Docker
+        # network where BuildKit runs.  We patch the file in-place; the context dir
+        # is a temp directory so this is safe to do.
+        if is_k3d and BUILDKIT_REGISTRY_HOST:
+            dockerfile_path = os.path.join(context_dir, "Dockerfile")
+            if os.path.exists(dockerfile_path):
+                with open(dockerfile_path, "r") as _f:
+                    _content = _f.read()
+                _new_content = _content.replace("tensorleap-registry:5000", BUILDKIT_REGISTRY_HOST)
+                if _new_content != _content:
+                    with open(dockerfile_path, "w") as _f:
+                        _f.write(_new_content)
+                    logger.info(f"Rewrote Dockerfile FROM: tensorleap-registry:5000 → {BUILDKIT_REGISTRY_HOST}")
+
+        build_cmd = [
+            "docker", "buildx", "build",
+            "--builder", builder_name,
+            "--cache-from", cache_from,
+            "--cache-to", cache_to,
+            "--tag", full_image_name,
+            "--progress", "plain",
+        ]
+        if push:
+            build_cmd.append("--push")
+        else:
+            build_cmd.append("--load")
+        build_cmd.append(context_dir)
+
+        logger.info(f"Running BuildKit build: {' '.join(build_cmd)}")
+
+        error_lines = []
+        log_lines = []
+
+        try:
+            process = subprocess.Popen(
+                build_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                universal_newlines=True
+            )
+
+            _LOG_LINE_OVERHEAD = 45
+            _RATE_LIMIT_BYTES = 100 * 1024
+            _RATE_WINDOW_SEC = 1.0
+            _rate_window_start = time.monotonic()
+            _rate_window_bytes = 0
+            _suppressed_count = 0
+
+            for line in process.stdout:
+                line = line.rstrip()
+                log_lines.append(line)
+                lower_line = line.lower()
+                if "error" in lower_line or "failed" in lower_line:
+                    error_lines.append(line)
+                now = time.monotonic()
+                msg = f"[BuildKit] {line}"
+                msg_bytes = len(msg.encode("utf-8", errors="replace")) + _LOG_LINE_OVERHEAD
+                if now - _rate_window_start >= _RATE_WINDOW_SEC:
+                    if _suppressed_count > 0:
+                        logger.info(f"[BuildKit] ... {_suppressed_count} lines suppressed (log rate limit) ...")
+                    _rate_window_start = now
+                    _rate_window_bytes = 0
+                    _suppressed_count = 0
+                is_important = "error" in lower_line or "failed" in lower_line
+                if is_important or _rate_window_bytes + msg_bytes <= _RATE_LIMIT_BYTES:
+                    logger.info(msg)
+                    _rate_window_bytes += msg_bytes
+                else:
+                    _suppressed_count += 1
+
+            if _suppressed_count > 0:
+                logger.info(f"[BuildKit] ... {_suppressed_count} lines suppressed (log rate limit) ...")
+
+            process.wait()
+
+            if log_file_path:
+                with open(log_file_path, "w") as f:
+                    f.write("\n".join(log_lines))
+                    if process.returncode == 0:
+                        f.write("\n\nSUMMARY: Build succeeded with BuildKit\n")
+                    else:
+                        f.write(f"\n\nSUMMARY: Build failed with exit code {process.returncode}\n")
+
+            if process.returncode == 0:
+                logger.info(f"Successfully built image: {full_image_name}")
+                return True, full_image_name, []
+            else:
+                logger.error(f"Build failed with exit code {process.returncode}")
+                return False, "", error_lines
+
+        except subprocess.SubprocessError as e:
+            error_msg = f"BuildKit build subprocess error: {e}"
+            logger.error(error_msg)
+            error_lines.append(error_msg)
+            return False, "", error_lines
+
+
+    def cleanup_builder(builder_name: str = BUILDER_NAME) -> bool:
+        try:
+            result = subprocess.run(
+                ["docker", "buildx", "rm", builder_name],
+                capture_output=True, text=True, timeout=30
+            )
+            return result.returncode == 0
+        except subprocess.SubprocessError:
+            return False

--- a/charts/tensorleap/charts/engine/templates/engine-job-template-cm.yaml
+++ b/charts/tensorleap/charts/engine/templates/engine-job-template-cm.yaml
@@ -57,9 +57,18 @@ data:
                 - name: no_proxy
                   value: {{ .Values.no_proxy | quote }}
               {{- end }}
+              {{- if .Values.buildkit_registry_host }}
+                - name: BUILDKIT_REGISTRY_HOST
+                  value: {{ .Values.buildkit_registry_host | quote }}
+              {{- end }}
               volumeMounts:
                 - name: shared-logs
                   mountPath: /shared/logs
+                - name: docker-sock
+                  mountPath: /var/run/docker.sock
+                - name: buildkit-helper-override
+                  mountPath: /app/buildkit_helper.py
+                  subPath: buildkit_helper.py
           containers:
             - image: {{ .Values.image_name }}:{{ .Values.image_tag }}
               imagePullPolicy: IfNotPresent
@@ -113,3 +122,10 @@ data:
                 path: {{ $dir }}
                 type: DirectoryOrCreate
 {{ end }}
+            - name: docker-sock
+              hostPath:
+                path: /var/run/docker.sock
+                type: Socket
+            - name: buildkit-helper-override
+              configMap:
+                name: buildkit-helper-override-cm

--- a/charts/tensorleap/charts/engine/values.yaml
+++ b/charts/tensorleap/charts/engine/values.yaml
@@ -1,4 +1,4 @@
-image_tag: master-f46acb40
+image_tag: master-2c133e0e
 image_name: public.ecr.aws/tensorleap/engine
 redis_image: docker.io/library/redis:8.6-alpine
 entry_point: generic_processor
@@ -11,8 +11,13 @@ redis_blob_pod_gb: 1
 redis_blob_maxmemory_mb: 768
 env_name: "on-prem"
 dependencies_image_name: public.ecr.aws/tensorleap/pippin
-dependencies_image_tag: master-d88fb971
+dependencies_image_tag: master-26a41e94
 target_repo: tensorleap-registry:5000
+# buildkit_registry_host is the host-accessible address for Zot used by
+# BuildKit (which runs in host-Docker network namespace and cannot resolve
+# the k8s-DNS name "tensorleap-registry"). Set by the installer to
+# "127.0.0.1:<registryPort>". Default covers the standard port 5699.
+buildkit_registry_host: "127.0.0.1:5699"
 generic_calculator_image: "public.ecr.aws/tensorleap/engine-generic"
 generic_py_ver: py38 #select from: py38, py39, py310, py311, py312
 

--- a/pkg/helm/utils.go
+++ b/pkg/helm/utils.go
@@ -42,6 +42,11 @@ type ServerHelmValuesParams struct {
 	DisableAuth            bool              `json:"disableAuth"`
 	InstalledServerVersion string            `json:"installedServerVersion"`
 	LocalBucketPath        string            `json:"localBucketPath"`
+	// BuildkitRegistryHost is the host-accessible address for the in-cluster Zot
+	// registry, used by BuildKit (which runs in the host Docker daemon's network
+	// namespace and cannot resolve the k8s-internal "tensorleap-registry:5000" name).
+	// Format: "127.0.0.1:<registryPort>" (e.g. "127.0.0.1:5699").
+	BuildkitRegistryHost string `json:"buildkitRegistryHost"`
 }
 
 type ZotSyncRegistry struct {
@@ -254,11 +259,12 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 
 	return Record{
 		"tensorleap-engine": Record{
-			"gpu":                  params.Gpu,
-			"localDataDirectories": params.LocalDataDirectories,
-			"http_proxy":           params.ProxyEnv["http_proxy"],
-			"https_proxy":          params.ProxyEnv["https_proxy"],
-			"no_proxy":             params.ProxyEnv["no_proxy"],
+			"gpu":                    params.Gpu,
+			"localDataDirectories":   params.LocalDataDirectories,
+			"http_proxy":             params.ProxyEnv["http_proxy"],
+			"https_proxy":            params.ProxyEnv["https_proxy"],
+			"no_proxy":               params.ProxyEnv["no_proxy"],
+			"buildkit_registry_host": params.BuildkitRegistryHost,
 		},
 		"tensorleap-node-server": Record{
 			"enableKeycloak":         params.KeycloakEnabled,

--- a/pkg/k3d/cluster.go
+++ b/pkg/k3d/cluster.go
@@ -1,8 +1,10 @@
 package k3d
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -578,12 +580,72 @@ func FixDockerDns() {
 // ImportImagesIntoCluster imports images from the host Docker daemon into the
 // k3s containerd store. Used during airgap bootstrap to load the Zot registry
 // image and k3s system images before any in-cluster registry is available.
+//
+// Images are imported one at a time via a direct docker-save | ctr-import pipeline
+// with --platform linux/amd64, bypassing multi-arch manifest list issues that cause
+// "content digest not found" errors when ctr tries to resolve arm64/arm manifests
+// that are referenced in the OCI index but not present in the docker save archive.
 func ImportImagesIntoCluster(ctx context.Context, cluster *Cluster, images []string) error {
 	if len(images) == 0 {
 		return nil
 	}
-	log.Infof("Importing %d images into cluster containerd...", len(images))
-	return k3dCluster.ImageImportIntoClusterMulti(ctx, runtimes.SelectedRuntime, images, cluster, k3d.ImageImportOpts{})
+	// Find the first server node name (k3d-tensorleap-server-0)
+	nodeName := ""
+	for _, node := range cluster.Nodes {
+		if node.Role == k3d.ServerRole {
+			nodeName = node.Name
+			break
+		}
+	}
+	if nodeName == "" {
+		return fmt.Errorf("no server node found in cluster %s", cluster.Name)
+	}
+
+	log.Infof("Importing %d images into cluster containerd (node: %s)...", len(images), nodeName)
+	for _, img := range images {
+		log.Infof("Importing image into containerd: %s", img)
+		if err := importImageWithPlatformFilter(ctx, nodeName, img); err != nil {
+			return fmt.Errorf("failed to import image %s: %w", img, err)
+		}
+	}
+	return nil
+}
+
+// importImageWithPlatformFilter pipes docker save → ctr image import with
+// --platform linux/amd64 to avoid multi-arch manifest list resolution errors.
+// Multi-arch images include manifests for arm64/arm/s390x in their OCI index,
+// but docker save only includes the current-platform (amd64) layers; ctr's
+// default import tries to resolve all referenced manifests and fails on the
+// missing non-amd64 ones.
+func importImageWithPlatformFilter(ctx context.Context, nodeName, image string) error {
+	pr, pw := io.Pipe()
+
+	saveCmd := exec.CommandContext(ctx, "docker", "save", image)
+	saveCmd.Stdout = pw
+
+	var importStdout, importStderr bytes.Buffer
+	importCmd := exec.CommandContext(ctx, "docker", "exec", "-i", nodeName,
+		"ctr", "image", "import", "--platform", "linux/amd64", "-")
+	importCmd.Stdin = pr
+	importCmd.Stdout = &importStdout
+	importCmd.Stderr = &importStderr
+
+	if err := importCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start ctr import: %w", err)
+	}
+
+	if err := saveCmd.Run(); err != nil {
+		pw.CloseWithError(err)
+		importCmd.Wait()
+		return fmt.Errorf("docker save failed for %s: %w", image, err)
+	}
+	pw.Close()
+
+	if err := importCmd.Wait(); err != nil {
+		return fmt.Errorf("ctr image import failed for %s: %w\nstdout: %s\nstderr: %s",
+			image, err, importStdout.String(), importStderr.String())
+	}
+	return nil
 }
 
 // isGpuDevicesUUIDs checks if gpuDevices contains GPU UUIDs (vs old-style indexes).

--- a/pkg/k3d/registry.go
+++ b/pkg/k3d/registry.go
@@ -176,6 +176,13 @@ func CacheImage(ctx context.Context, dockerClient docker.Client, image string, r
 		}
 
 		if !imageAlreadyInRegistry {
+			// Manifest-list images fail Docker push with "does not provide any platform".
+			// Fall back to extracting the linux/amd64 manifest directly from docker save
+			// and pushing it to Zot via the OCI HTTP API.
+			if strings.Contains(string(pushImageOutput), "does not provide any platform") {
+				log.Infof("Manifest-list push failed; falling back to direct amd64 OCI push for %s\n", image)
+				return pushAmd64ManifestToRegistry(ctx, image, regPort)
+			}
 
 			if retry > 0 {
 				retry--
@@ -311,6 +318,59 @@ func CheckDockerRequirements(checkDockerRequirementImage string, isAirgap bool) 
 		if err := askToContinueWithStorageIssue("Docker resources are below recommended levels. Do you want to continue anyway?"); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// pushAmd64ManifestToRegistry handles manifest-list images that Docker's
+// ImagePush rejects with "does not provide any platform".  It uses
+// `docker buildx imagetools inspect --raw` to find the linux/amd64 digest
+// and then `docker buildx imagetools create` to copy only that manifest
+// (and its blobs) from the local containerd image store to Zot.
+func pushAmd64ManifestToRegistry(ctx context.Context, image, regPort string) error {
+	// Get the raw manifest JSON so we can find the amd64 platform digest.
+	rawOut, err := exec.CommandContext(ctx,
+		"docker", "buildx", "imagetools", "inspect", "--raw", image).Output()
+	if err != nil {
+		return fmt.Errorf("imagetools inspect failed for %s: %w", image, err)
+	}
+
+	var manifestList struct {
+		Manifests []struct {
+			Digest   string `json:"digest"`
+			Platform struct {
+				Architecture string `json:"architecture"`
+				OS           string `json:"os"`
+			} `json:"platform"`
+		} `json:"manifests"`
+	}
+	if err := json.Unmarshal(rawOut, &manifestList); err != nil {
+		return fmt.Errorf("parsing manifest list for %s: %w", image, err)
+	}
+
+	var amd64Digest string
+	for _, m := range manifestList.Manifests {
+		if m.Platform.Architecture == "amd64" && m.Platform.OS == "linux" {
+			amd64Digest = m.Digest
+			break
+		}
+	}
+	if amd64Digest == "" {
+		return fmt.Errorf("no linux/amd64 manifest found in image %s", image)
+	}
+
+	targetImage := fmt.Sprintf("127.0.0.1:%s%s", regPort,
+		strings.TrimLeftFunc(image, func(r rune) bool { return r != '/' }))
+	sourceRef := image + "@" + amd64Digest
+
+	log.Infof("Copying amd64 manifest %s → %s via imagetools\n", sourceRef, targetImage)
+	out, err := exec.CommandContext(ctx,
+		"docker", "buildx", "imagetools", "create",
+		"--tag", targetImage, sourceRef).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("imagetools create failed for %s: %w\noutput: %s",
+			image, err, string(out))
 	}
 
 	return nil

--- a/pkg/server/installation_params.go
+++ b/pkg/server/installation_params.go
@@ -853,6 +853,7 @@ func (params *InstallationParams) GetServerHelmValuesParams(versionTag string) *
 		DisableAuth:            params.DisabledAuth,
 		InstalledServerVersion: versionTag,
 		LocalBucketPath:        localBucketPath,
+		BuildkitRegistryHost:   fmt.Sprintf("127.0.0.1:%d", params.RegistryPort),
 	}
 }
 
@@ -953,6 +954,7 @@ func (params *InstallationParams) GetCreateK3sClusterParams() *k3d.CreateK3sClus
 	standaloneDir := local.GetServerDataDir()
 	volumes := []string{
 		fmt.Sprintf("%v:%v", standaloneDir, local.DEFAULT_DATA_DIR),
+		"/var/run/docker.sock:/var/run/docker.sock",
 	}
 	volumes = append(volumes, params.DatasetVolumes...)
 


### PR DESCRIPTION
## Summary
- Reverts the earlier revert of #408, restoring the fix for BuildKit registry DNS and manifest-list push issues during airgap installs (pippin's build-cache step couldn't resolve the in-cluster `tensorleap-registry:5000` Zot registry from the host-run BuildKit builder).
- Bumps `charts/tensorleap/Chart.yaml` to a new minor version so the installer's reinstall-required check forces a fresh k3d node — the fix mounts `/var/run/docker.sock` into the node at cluster-creation time (`pkg/k3d/cluster.go`), which only takes effect on a new node, not an in-place upgrade of an existing one. This was very likely why #408 looked broken and got reverted the first time: testing via upgrade silently skipped the mount.

## Test plan
- [ ] `helm lint charts/tensorleap`
- [ ] Fresh airgap install (not upgrade) on a clean k3d node, confirm no BuildKit registry DNS / manifest-list errors during the pippin build-cache step
- [ ] `leap push --eval` against the fresh cluster to exercise the pippin BuildKit path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)