### PR TITLE
Resolve kubectl kubeconfig from standalone copy in all shells

### DIFF
--- a/cmd/server/tools.go
+++ b/cmd/server/tools.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"context"
 	"os"
 
-	k3d "github.com/k3d-io/k3d/v5/cmd"
+	k3dcmd "github.com/k3d-io/k3d/v5/cmd"
 	"github.com/spf13/cobra"
+	"github.com/tensorleap/helm-charts/pkg/k3d"
+	"github.com/tensorleap/helm-charts/pkg/log"
 	"github.com/tensorleap/helm-charts/pkg/server"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	kubectl "k8s.io/kubectl/pkg/cmd"
@@ -17,7 +20,7 @@ func NewToolCmd() *cobra.Command {
 		Long:  `3rd party tools to help manage local environment`,
 	}
 
-	cmd.AddCommand(k3d.NewCmdK3d())
+	cmd.AddCommand(k3dcmd.NewCmdK3d())
 	cmd.AddCommand(newTensorleapKubectlCommand())
 
 	return cmd
@@ -37,7 +40,56 @@ func newTensorleapKubectlCommand() *cobra.Command {
 		IOStreams:     genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
 	})
 
+	// Resolve the kubeconfig lazily at run time — not at construction, which runs
+	// for every `leap` invocation — so the Docker self-heal fallback only happens
+	// when this command is actually used, and only when needed. Chain kubectl's own
+	// persistent pre-run hook so its setup still runs.
+	origPreRunE := kubectlCmd.PersistentPreRunE
+	origPreRun := kubectlCmd.PersistentPreRun
+	kubectlCmd.PersistentPreRun = nil
+	kubectlCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		setDefaultKubeConfig(cmd.Context(), configFlags)
+		if origPreRunE != nil {
+			return origPreRunE(cmd, args)
+		}
+		if origPreRun != nil {
+			origPreRun(cmd, args)
+		}
+		return nil
+	}
+
 	return kubectlCmd
+}
+
+// setDefaultKubeConfig points `leap server tools kubectl` at the standalone
+// kubeconfig the installer keeps current, so it reaches the live cluster in ALL
+// shell contexts — not only login shells where the installer's
+// /etc/profile.d/tensorleap-kubeconfig.sh drop-in exports KUBECONFIG. A non-login
+// shell (e.g. a CI `run:` step) leaves KUBECONFIG unset and would otherwise fall
+// back to ~/.kube/config, which drifts stale because k3d picks a new random API
+// port each install (see pkg/k3d.createClusterConfig).
+//
+// Precedence, highest first:
+//  1. an explicit --kubeconfig flag (cobra has already parsed it into the pointer),
+//  2. a user-set $KUBECONFIG,
+//  3. the standalone kubeconfig (regenerated from the live cluster if missing),
+//  4. kubectl's default resolution (~/.kube/config), used if the standalone copy
+//     can't be resolved.
+func setDefaultKubeConfig(ctx context.Context, configFlags *genericclioptions.ConfigFlags) {
+	if configFlags.KubeConfig != nil && *configFlags.KubeConfig != "" {
+		return // explicit --kubeconfig wins
+	}
+	if os.Getenv("KUBECONFIG") != "" {
+		return // respect a user-set $KUBECONFIG
+	}
+	path, err := k3d.ResolveSharedKubeConfig(ctx)
+	if err != nil {
+		log.Warnf("Could not resolve standalone kubeconfig, using default resolution: %v", err)
+		return
+	}
+	if path != "" {
+		configFlags.KubeConfig = &path
+	}
 }
 
 func init() {

--- a/pkg/k3d/cluster.go
+++ b/pkg/k3d/cluster.go
@@ -185,13 +185,8 @@ func updateContainerCPU(containerID, cpuLimit string) error {
 // local user is cluster-admin. Fine on a shared dev box (data dir is already
 // 777); switch to a group + 640 if not.
 func writeSharedKubeConfig(ctx context.Context, cluster *Cluster) error {
-	sharedPath := local.GetKubeConfigPath()
-	if _, err := k3dCluster.KubeconfigGetWrite(ctx, runtimes.SelectedRuntime, cluster, sharedPath,
-		&k3dCluster.WriteKubeConfigOptions{OverwriteExisting: true}); err != nil {
-		return err
-	}
-	// World-accessible so any local user can read it (matches the 777 data dir).
-	if err := os.Chmod(sharedPath, 0777); err != nil {
+	sharedPath, err := writeSharedKubeConfigFile(ctx, cluster)
+	if err != nil {
 		return err
 	}
 
@@ -202,6 +197,52 @@ func writeSharedKubeConfig(ctx context.Context, cluster *Cluster) error {
 	// is a plain filesystem path (no shell metachars), so this is safe to quote.
 	return local.RunCommand("sudo", "sh", "-c",
 		"echo 'export KUBECONFIG="+sharedPath+"' > /etc/profile.d/tensorleap-kubeconfig.sh")
+}
+
+// writeSharedKubeConfigFile writes the cluster kubeconfig to the stable shared
+// path in the data dir and makes it world-readable, returning that path. Unlike
+// writeSharedKubeConfig it does NOT touch shell profiles — that login-shell
+// wiring is install-only, whereas this file write is also used to self-heal a
+// missing shared kubeconfig at kubectl time (see ResolveSharedKubeConfig).
+func writeSharedKubeConfigFile(ctx context.Context, cluster *Cluster) (string, error) {
+	sharedPath := local.GetKubeConfigPath()
+	if _, err := k3dCluster.KubeconfigGetWrite(ctx, runtimes.SelectedRuntime, cluster, sharedPath,
+		&k3dCluster.WriteKubeConfigOptions{OverwriteExisting: true}); err != nil {
+		return "", err
+	}
+	// World-accessible so any local user can read it (matches the 777 data dir).
+	if err := os.Chmod(sharedPath, 0777); err != nil {
+		return "", err
+	}
+	return sharedPath, nil
+}
+
+// ResolveSharedKubeConfig returns the path to the shared standalone kubeconfig
+// used by `leap server tools kubectl`, or "" (with no error) when it cannot be
+// resolved and the caller should fall back to kubectl's default resolution
+// (~/.kube/config).
+//
+// Fast path: if the shared file already exists it is returned as-is, with no
+// Docker interaction — the common case, since the installer writes and keeps it
+// current (with the live API port) on every (re)install.
+//
+// Self-heal path: if the file is missing but the tensorleap cluster is running,
+// it is regenerated from the live cluster so it reflects the current API port.
+// Docker is only touched in that rare case, keeping the hot path cheap.
+func ResolveSharedKubeConfig(ctx context.Context) (string, error) {
+	sharedPath := local.GetKubeConfigPath()
+	if _, err := os.Stat(sharedPath); err == nil {
+		return sharedPath, nil
+	}
+
+	cluster, err := GetCluster(ctx)
+	if err != nil {
+		return "", fmt.Errorf("detecting running cluster to regenerate kubeconfig: %w", err)
+	}
+	if cluster == nil {
+		return "", nil
+	}
+	return writeSharedKubeConfigFile(ctx, cluster)
 }
 
 func CreateTmpClusterKubeConfig(ctx context.Context, cluster *Cluster) (string, func(), error) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 
 // When upgrading major number(the middle digit) it will require reinstall
 
-const Version = "v0.10.13"
+const Version = "v0.10.14"
 
 func IsMinorVersionSmaller(currentVersion, comperedVersion string) bool {
 


### PR DESCRIPTION
## Problem

`leap server tools kubectl` relied on kubectl's default kubeconfig resolution (`$KUBECONFIG` → `~/.kube/config`). The installer only exports `KUBECONFIG` via `/etc/profile.d/tensorleap-kubeconfig.sh`, which **login** shells read but **non-login** shells do not — GitHub Actions `run:` steps, systemd services, and plain scripts all run in non-login shells.

In those shells `KUBECONFIG` is unset, so kubectl fell back to `~/.kube/config`, which drifts stale: k3d picks a **new random API host port on every (re)install** (`pkg/k3d.createClusterConfig` → `cliutil.GetFreePort()`). The result was `connection refused` on every `leap server tools kubectl` call — this masked itself for days because interactive SSH (a login shell) worked fine.

Observed on two self-hosted GPU runners the same day:

| box | live k3d port | standalone kubeconfig | non-login `leap kubectl` |
|---|---|---|---|
| runner-1 | 46431 | 46431 ✓ | stale ✗ |
| runner-2 | 36965 | 36965 ✓ | 41985 (dead) ✗ |

## Fix

Resolve the kubeconfig ourselves instead of leaning on the environment, **lazily at run time** (in a chained `PersistentPreRunE`) so unrelated `leap` commands never pay for it. Precedence, highest first:

```
--kubeconfig flag  >  $KUBECONFIG  >  standalone kubeconfig  >  ~/.kube/config
```

- The **standalone copy** (`…/manifests/kubeconfig.yaml`, kept current by the installer on every install with the live port) is preferred via a plain **file read — no Docker**. This is the hot path used by CI monitoring loops.
- If that file is **missing but the cluster is running**, it's regenerated from the live cluster (**self-heal**). Docker is only touched in that rare case.
- Otherwise it falls through to kubectl's default `~/.kube/config`, unchanged.

This makes `leap server tools kubectl` reach the live cluster in **all** shell contexts (login or not) and stable across reinstalls, removing the need for the CI-side `KUBECONFIG`-capture workaround (leap-runner #38) for this command. It's strictly an improvement — no existing user's behavior regresses (a set `$KUBECONFIG` or `--kubeconfig` still wins).

### Scope
Covers `leap server tools kubectl` only (the tool CI monitoring uses). Bare `kubectl`/`helm` in non-login shells are intentionally out of scope.

## Changes
- `cmd/server/tools.go` — lazy kubeconfig resolution via chained `PersistentPreRunE` + `setDefaultKubeConfig`.
- `pkg/k3d/cluster.go` — split file-write out of `writeSharedKubeConfig` into `writeSharedKubeConfigFile`; add `ResolveSharedKubeConfig` (fast file read + self-heal fallback).
- `pkg/version/version.go` — `v0.10.13` → `v0.10.14` (patch; no reinstall semantics).

## Verification
- `go build ./...` ✅  `go vet` ✅  `go test ./...` ✅ (incl. `-race` on `pkg/k3d`)  `gofmt -l` clean ✅
- `golangci-lint run --new-from-rev=HEAD` → **0 new issues**. (Repo-wide `make lint` reports pre-existing `errcheck` warnings unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)