### PR TITLE
Install-time pip index URL flags routed to node-server

### DIFF
--- a/charts/tensorleap/Chart.yaml
+++ b/charts/tensorleap/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tensorleap
 type: application
-version: 1.6.50
+version: 1.6.52
 dependencies:
   - name: ingress-nginx
     version: 4.10.0

--- a/charts/tensorleap/charts/node-server/Chart.yaml
+++ b/charts/tensorleap/charts/node-server/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: tensorleap-node-server
 type: application
-version: 1.0.524
+version: 1.0.525

--- a/charts/tensorleap/charts/node-server/templates/node-server-env-configmap.yaml
+++ b/charts/tensorleap/charts/node-server/templates/node-server-env-configmap.yaml
@@ -50,3 +50,9 @@ data:
 {{- else if .Values.global.namespacedInstall }}
   TARGET_NAMESPACE: {{ .Release.Namespace }}
 {{- end }}
+{{- if .Values.pipIndexUrl }}
+  PIP_INDEX_URL: {{ .Values.pipIndexUrl | quote }}
+{{- end }}
+{{- if .Values.pipExtraIndexUrl }}
+  PIP_EXTRA_INDEX_URL: {{ .Values.pipExtraIndexUrl | quote }}
+{{- end }}

--- a/charts/tensorleap/charts/node-server/values.yaml
+++ b/charts/tensorleap/charts/node-server/values.yaml
@@ -14,4 +14,10 @@ mongodb:
 
 localBucketPath: ""
 
+# Install-time default pip index for dependency builds (e.g. internal PyPI
+# mirror on airgap installs); set by the installer. Empty = public PyPI.
+# Editable per-installation via the web UI engine settings.
+pipIndexUrl: ""
+pipExtraIndexUrl: ""
+
 mongodb_image: docker.io/library/mongo:6.0.5

--- a/pkg/helm/utils.go
+++ b/pkg/helm/utils.go
@@ -38,6 +38,8 @@ type ServerHelmValuesParams struct {
 	HostName               string            `json:"hostname"`
 	DatadogEnv             map[string]string `json:"datadogEnv"`
 	ProxyEnv               map[string]string `json:"proxyEnv"`
+	PipIndexUrl            string            `json:"pipIndexUrl"`
+	PipExtraIndexUrl       string            `json:"pipExtraIndexUrl"`
 	KeycloakEnabled        bool              `json:"keycloakEnabled"`
 	DisableAuth            bool              `json:"disableAuth"`
 	InstalledServerVersion string            `json:"installedServerVersion"`
@@ -266,6 +268,8 @@ func CreateTensorleapChartValues(params *ServerHelmValuesParams) (Record, error)
 			"disableDatadogMetrics":  params.DisableDatadogMetrics,
 			"installedServerVersion": params.InstalledServerVersion,
 			"localBucketPath":        params.LocalBucketPath,
+			"pipIndexUrl":            params.PipIndexUrl,
+			"pipExtraIndexUrl":       params.PipExtraIndexUrl,
 		},
 		"global": Record{
 			"domain":               params.Domain,

--- a/pkg/helm/utils_test.go
+++ b/pkg/helm/utils_test.go
@@ -19,8 +19,10 @@ func TestCreateTensorleapChartValues(t *testing.T) {
 				Cert:    "",
 				Key:     "",
 			},
-			HostName:        "nsa.gov",
-			KeycloakEnabled: true,
+			HostName:         "nsa.gov",
+			KeycloakEnabled:  true,
+			PipIndexUrl:      "http://pypi.local/simple",
+			PipExtraIndexUrl: "http://pypi2.local/simple",
 		}
 
 		expected := Record{
@@ -37,6 +39,8 @@ func TestCreateTensorleapChartValues(t *testing.T) {
 				"disableDatadogMetrics":  params.DisableDatadogMetrics,
 				"installedServerVersion": params.InstalledServerVersion,
 				"localBucketPath":        params.LocalBucketPath,
+				"pipIndexUrl":            "http://pypi.local/simple",
+				"pipExtraIndexUrl":       "http://pypi2.local/simple",
 			},
 			"global": Record{
 				"domain":               "",

--- a/pkg/server/flags.go
+++ b/pkg/server/flags.go
@@ -76,6 +76,8 @@ type InstallFlags struct {
 	Domain                  string   `json:"domain"`
 	DataDir                 string   `json:"dataDir"`
 	ProxyUrl                string   `json:"ProxyUrl"`
+	PipIndexUrl             string   `json:"pipIndexUrl,omitempty"`
+	PipExtraIndexUrl        string   `json:"pipExtraIndexUrl,omitempty"`
 	CpuLimit                string   `json:"cpuLimit,omitempty"`
 	DisableAuth             *bool    `json:"disableAuth,omitempty"`
 	ClearInstallationImages *bool    `json:"removeInstallationImages,omitempty"`
@@ -93,6 +95,8 @@ func (flags *InstallFlags) SetFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&flags.DisableMetrics, "disable-metrics", false, "Disable metrics collection")
 	cmd.Flags().StringVar(&flags.Domain, "domain", "localhost", "Domain to be used for tensorleap server")
 	cmd.Flags().StringVar(&flags.ProxyUrl, "proxy-url", "", "Proxy URL to be used for tensorleap server")
+	cmd.Flags().StringVar(&flags.PipIndexUrl, "pip-index-url", "", "Pip index URL used as the default for dependency builds (e.g. internal PyPI mirror on airgap); falls back to PIP_INDEX_URL env, then previous installation")
+	cmd.Flags().StringVar(&flags.PipExtraIndexUrl, "pip-extra-index-url", "", "Extra pip index URL for dependency builds; falls back to PIP_EXTRA_INDEX_URL env, then previous installation")
 	cmd.Flags().StringVarP(&flags.DataDir, "data-dir", "d", "", "Directory to store tensorleap data, by default using /var/lib/tensorleap/standalone or previous data directory")
 	cmd.Flags().StringVar(&flags.CpuLimit, "cpu-limit", "", "Limit the CPU resources for the k3d cluster (e.g. 2 for 2 cores)")
 	setNilBoolFlag(cmd, &flags.DisableAuth, "disable-auth", "Disable authentication for the tensorleap server")

--- a/pkg/server/installation_params.go
+++ b/pkg/server/installation_params.go
@@ -30,6 +30,8 @@ type InstallationParams struct {
 	Port                        uint                   `json:"clusterPort"`
 	Domain                      string                 `json:"domain"`
 	ProxyUrl                    string                 `json:"proxyUrl"`
+	PipIndexUrl                 string                 `json:"pipIndexUrl,omitempty"`
+	PipExtraIndexUrl            string                 `json:"pipExtraIndexUrl,omitempty"`
 	RegistryPort                uint                   `json:"registryPort"`
 	DisableMetrics              bool                   `json:"disableMetrics"`
 	DatasetDirectory_DEPRECATED string                 `json:"datasetDirectory,omitempty" yaml:"datasetDirectory,omitempty"`
@@ -176,6 +178,13 @@ func InitInstallationParamsFromFlags(flags *InstallFlags, isAirgap bool) (*Insta
 		return nil, fmt.Errorf("failed to get TLS params: %v", err)
 	}
 
+	if flags.PipIndexUrl == "" {
+		flags.PipIndexUrl = lookupFirstEnv("PIP_INDEX_URL")
+	}
+	if flags.PipExtraIndexUrl == "" {
+		flags.PipExtraIndexUrl = lookupFirstEnv("PIP_EXTRA_INDEX_URL")
+	}
+
 	if hasInstallationParams {
 		shouldAskForPreviousTLSConfig := previousParams.TLSParams.Enabled && !tlsParams.Enabled
 		if shouldAskForPreviousTLSConfig {
@@ -214,6 +223,13 @@ func InitInstallationParamsFromFlags(flags *InstallFlags, isAirgap bool) (*Insta
 			}
 		}
 
+		if flags.PipIndexUrl == "" {
+			flags.PipIndexUrl = previousParams.PipIndexUrl
+		}
+		if flags.PipExtraIndexUrl == "" {
+			flags.PipExtraIndexUrl = previousParams.PipExtraIndexUrl
+		}
+
 		isRemoveInstallationNotSet := flags.ClearInstallationImages == nil
 		if isRemoveInstallationNotSet {
 			flags.ClearInstallationImages = &previousParams.ClearInstallationImages
@@ -248,6 +264,8 @@ func InitInstallationParamsFromFlags(flags *InstallFlags, isAirgap bool) (*Insta
 		DatasetVolumes:          flags.DatasetVolumes,
 		Domain:                  flags.Domain,
 		ProxyUrl:                flags.ProxyUrl,
+		PipIndexUrl:             flags.PipIndexUrl,
+		PipExtraIndexUrl:        flags.PipExtraIndexUrl,
 		CpuLimit:                flags.CpuLimit,
 		TLSParams:               *tlsParams,
 		ClearInstallationImages: *flags.ClearInstallationImages,
@@ -849,6 +867,8 @@ func (params *InstallationParams) GetServerHelmValuesParams(versionTag string) *
 		Tls:                    *tlsParams,
 		DatadogEnv:             datadogEnvs,
 		ProxyEnv:               proxyEnvs,
+		PipIndexUrl:            params.PipIndexUrl,
+		PipExtraIndexUrl:       params.PipExtraIndexUrl,
 		KeycloakEnabled:        !params.DisabledAuth,
 		DisableAuth:            params.DisabledAuth,
 		InstalledServerVersion: versionTag,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 
 // When upgrading major number(the middle digit) it will require reinstall
 
-const Version = "v0.10.13"
+const Version = "v0.10.14"
 
 func IsMinorVersionSmaller(currentVersion, comperedVersion string) bool {
 


### PR DESCRIPTION
## What

Let customers declare a pip index URL at install time and cascade it to node-server.

- New install flags `--pip-index-url` / `--pip-extra-index-url` (fallback to `PIP_INDEX_URL` / `PIP_EXTRA_INDEX_URL` env, then previously-saved params).
- **Persisted** in `InstallationParams` so `leap server upgrade` (which takes no install flags and rebuilds values from saved params) keeps them.
- Rendered into the node-server env configmap **only when set** (`{{- if .Values.pipIndexUrl }}`), so the default stays undefined like today.
- Values routed to the **`tensorleap-node-server`** chart values (not engine). Engine chart / pippin job template untouched — node-server injects the pip envs into the pippin init container from its settings at job-build time.
- Version bumps: node-server subchart `1.0.525`, umbrella `1.6.52`, installer `v0.10.14`.

## Why

Airgap installs need dependency builds to hit an internal PyPI mirror. This provides the mirror at install time; node-server uses it as the default for the engine pip settings, and users can still override it in the web UI (paired node-server PR).

## Testing

- `go build ./...`, `go test ./pkg/helm/... ./pkg/server/...` green (`utils_test.go` asserts the values pass through to the node-server record).
- `helm template` with `--set tensorleap-node-server.pipIndexUrl=…` → `PIP_INDEX_URL` appears **only** in `tensorleap-node-server-env-configmap`; default render → no `PIP_` output. helm-chart-validation pipeline run.
- E2E on a local install: the value reaches the node-server configmap → pod env → pippin `image-dependencies-builder` init container.

## Note

Scope kept minimal: no CLI flag to *blank* a persisted URL (an empty flag falls back to env/previous). To change it, pass a new value; the web-UI override also takes precedence. Say the word if a clear-flag is wanted.

Paired PR: tensorleap/node-server#1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)
