### PR TITLE
Fix rc_branch capturing two-line output in patch workflow

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -33,7 +33,10 @@ jobs:
         id: checkout_rc_branch
         run: |
           set -euo pipefail
-          BRANCH="$(make -s checkout-rc-branch)"
+          # checkout-rc-branch prints the branch name on the first line and the
+          # is_new_branch flag on the second; take only the first line.
+          OUTPUT="$(make -s checkout-rc-branch)"
+          BRANCH="$(echo "$OUTPUT" | head -1)"
           if [ -z "$BRANCH" ]; then
             echo "Error: Failed to get branch name from checkout-rc-branch" >&2
             exit 1


### PR DESCRIPTION
## Problem

`make checkout-rc-branch` prints **two** lines to stdout — the branch name followed by the `is_new_branch` flag (see `Makefile:155-156`). The Patch workflow captured *both* lines into `rc_branch`:

```bash
BRANCH="$(make -s checkout-rc-branch)"   # → "1.4.75\nfalse"
echo "rc_branch=$BRANCH" >> "$GITHUB_OUTPUT"
```

Writing a multi-line value this way leaks the stray flag line into `$GITHUB_OUTPUT` (either mangling `rc_branch` or triggering an "Invalid format" error on the runner).

## Fix

Take only the first line, matching the pattern already used in `release_candidate.yml`:

```bash
OUTPUT="$(make -s checkout-rc-branch)"
BRANCH="$(echo "$OUTPUT" | head -1)"
```

Workflow-only change — no chart touched, so no `Chart.yaml` bump or `images.txt` regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)