### PR TITLE
Notify Slack when release notes generation fails

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -97,6 +97,7 @@ jobs:
           python-version: '3.12'
 
       - name: Generate Release Notes & Update Jira fixVersion
+        id: release_notes
         continue-on-error: true
         env:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
@@ -197,6 +198,32 @@ jobs:
           if ! echo "$COMPLETE_RESP" | grep -q '"ok":true'; then
             echo "$COMPLETE_RESP" && exit 1
           fi
+
+      # Release notes are best-effort (continue-on-error above) so a Jira outage
+      # never blocks a release. Surface the failure in the release thread instead,
+      # otherwise it goes unnoticed while the job still reports success.
+      - name: Notify Slack - Release notes generation failed
+        if: steps.release_notes.outcome == 'failure'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TOKEN }}
+          payload: >
+            {
+              "channel": "C0A2J51FBPD",
+              "thread_ts": "${{ steps.slack_release.outputs.ts }}",
+              "text": "⚠️ Release notes generation failed for v${{ steps.get_version.outputs.version }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "⚠️ *Release notes were not generated for v${{ steps.get_version.outputs.version }}*\nThe release itself completed — only the Jira release notes step failed, so no `RELEASE_NOTES.md` was committed and no Jira `fixVersion` was set.\n\n*Most likely cause:* the `JIRA_API_TOKEN` secret expired or was revoked (Atlassian API tokens expire).\n• *Logs:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\n• *Rotate:* <https://id.atlassian.com/manage-profile/security/api-tokens|Atlassian API tokens> → then update the `JIRA_API_TOKEN` repo secret"
+                  }
+                }
+              ]
+            }
 
   release-airgap:
     name: Release Airgap Pack


### PR DESCRIPTION
## Why

`Generate Release Notes & Update Jira fixVersion` runs with `continue-on-error: true` so a Jira outage can never block a production release. The side effect: when `JIRA_API_TOKEN` was revoked, the step failed on **every production release from 1.6.2 (May 6) through 1.6.58 (Aug 3)** — 11 releases — while the job kept reporting success. The only signal was a `::warning::` annotation nobody reads. Last release notes actually committed: `v1.5.82`, 2026-04-15.

## What

- Give the step an `id` and post a warning into the existing release thread when it fails.
- Keys off `steps.release_notes.outcome`, not `conclusion` — under `continue-on-error` the conclusion is rewritten to `success`, so `outcome` is the only field that still reports the failure.
- Placed after `Notify Slack - Release Complete` so `steps.slack_release.outputs.ts` is available and the warning threads under the release message.
- Itself `continue-on-error`, so a Slack problem can't fail the release either.

Behaviour is unchanged on the happy path: no extra message when release notes generate normally.

## Verification

- YAML parses; both Slack payloads are valid JSON with expressions substituted.
- Step ordering confirmed: `get_version` → `release_notes` → `slack_release` → new step.
- The "no issues found" case (script exits early, writes no file) is *not* a failure, so it correctly stays silent.

## Related

Complements #417, which hardens the Jira auth path and untracks `.env`. This PR is only about making the failure visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)