### PR TITLE
Add `make run-local` wrapper for the local install flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,24 @@ build-helm:
 	helm dependency build ./charts/tensorleap-infra
 	rm ./charts/tensorleap-infra/Chart.lock
 
-
+# One-shot local dev install: pull chart deps, regenerate + validate images.txt,
+# then run the installer against the local charts. build-helm runs first because
+# update-images calls `helm template`, which needs the dependency tarballs.
+# Any installer flag is forwarded verbatim via ARGS, e.g.
+#   make run-local
+#   make run-local ARGS="--yes"
+#   make run-local ARGS="--cpu --gpus 1 --domain localhost --yes"
+# is equivalent to: go run . install --local $(ARGS)
+# Run `go run . install --help` for the full flag list.
+# .ONESHELL is in effect for this Makefile, so `set -e` is what stops the chain
+# on a failed step instead of falling through to the install.
+.PHONY: run-local
+run-local:
+	@set -euo pipefail
+	$(MAKE) build-helm
+	$(MAKE) update-images
+	$(MAKE) validate-images
+	go run . install --local $(ARGS)
 
 .PHONY: checkout-rc-branch
 .ONESHELL:


### PR DESCRIPTION
## What

Adds a single `make run-local` target so a local dev install is one command instead of remembering the prep chain:

```bash
make run-local
```

It runs `build-helm` → `update-images` → `validate-images`, then `go run . install --local`.

## Passing installer flags

Flags are forwarded verbatim via `ARGS`, matching the convention already used by `install-existing-cluster`:

```bash
make run-local ARGS="--production-monitor --yes"
```

Any flag from `go run . install --help` works with no further Makefile changes.

## Notes on two non-obvious details

- **Step order is `build-helm` first.** `update-images` calls `helm template`, and the external dependency tarballs (`ingress-nginx`, `keycloakx`, `datadog`, `eck-operator`) are not tracked in git — so on a fresh clone `update-images` fails unless `build-helm` has pulled them.
- **`set -euo pipefail` is load-bearing.** `.ONESHELL:` is declared in this Makefile and is a *global* special target, so under a make that honors it (3.82+, i.e. Linux/CI) all recipe lines share one shell and a failed `build-helm` would otherwise fall straight through to installing anyway.

## Testing

- Ran `build-helm`, `update-images` and `validate-images` for real — all pass (`✅ images.txt is valid (22 images)`), and the regeneration left `images.txt` byte-identical.
- Verified `ARGS` forwarding with `make -n run-local` for both the no-args and with-args cases.
- The actual cluster install was not run.

No chart changes, so no `Chart.yaml` version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)