### PR TITLE
Patch CoreDNS to Guaranteed QoS (512Mi) on install/upgrade

### DIFF
--- a/pkg/k3d/coredns.go
+++ b/pkg/k3d/coredns.go
@@ -1,0 +1,51 @@
+package k3d
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/tensorleap/helm-charts/pkg/log"
+)
+
+const (
+	corednsCpu    = "250m"
+	corednsMemory = "512Mi"
+)
+
+// PatchCoreDnsResources sets requests==limits on CoreDNS so it runs as Guaranteed QoS:
+// the k3s default (70Mi request / 170Mi limit, Burstable) both OOM-kills CoreDNS under
+// the engine's DNS query storms and makes it the kernel OOM killer's first victim under
+// node memory pressure (oom_score_adj ~999 vs -997 for Guaranteed). k3s only re-applies
+// its packaged coredns manifest when the k3s version changes, which happens exclusively
+// through install/upgrade — so re-patching here keeps the change durable.
+func PatchCoreDnsResources(ctx context.Context, kubeConfigPath, kubeContext string) error {
+	restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
+		&clientcmd.ConfigOverrides{CurrentContext: kubeContext},
+	).ClientConfig()
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig for coredns patch: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client for coredns patch: %w", err)
+	}
+
+	patch := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":"coredns","resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}]}}}}`,
+		corednsCpu, corednsMemory, corednsCpu, corednsMemory)
+
+	_, err = clientset.AppsV1().Deployments("kube-system").Patch(
+		ctx, "coredns", types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch coredns resources: %w", err)
+	}
+
+	log.Infof("Patched coredns resources to Guaranteed QoS (cpu %s, memory %s)", corednsCpu, corednsMemory)
+	return nil
+}

--- a/pkg/server/install.go
+++ b/pkg/server/install.go
@@ -228,6 +228,10 @@ func InstallCharts(ctx context.Context, mnf *manifest.InstallationManifest, inst
 		defer monitor.Stop()
 	}
 
+	if err := k3d.PatchCoreDnsResources(ctx, kubeConfigPath, KUBE_CONTEXT); err != nil {
+		log.Warnf("Could not patch coredns resources: %v", err)
+	}
+
 	infraChartMeta := mnf.InfraHelmChart
 	isInfraReleaseExisted, err := helm.IsHelmReleaseExists(helmConfig, infraChartMeta.ReleaseName)
 	if err != nil {


### PR DESCRIPTION
## Problem
Job `6a72dcab1cb352aece90aa0e` (trial appliance, Aug 5) failed after a ~4-minute cluster-wide DNS outage (`EAI_AGAIN` for all new lookups, 08:08–08:12 UTC): the streaming-PCA fit died mid blob-load and its fallback hit the same outage, failing an 84-minute evaluate job.

k3s default CoreDNS spec is the enabler:
- `memory limit 170Mi` — sized for idle clusters; the engine's LS-load phase generates an ndots-amplified DNS query storm (connection churn against minio, each unqualified lookup fans out 4–8 UDP queries) that pushes CoreDNS's heap past the limit → cgroup OOM kill.
- `Burstable` QoS with a 70Mi request → `oom_score_adj ≈ 999`, so under node memory pressure the kernel kills CoreDNS *before* the job pods causing the pressure (Guaranteed pods sit at −997).
- Single replica + CrashLoopBackOff (10s→…→160s) turns repeated kills into a multi-minute total DNS outage — matching the observed window.

## Fix
Patch `kube-system/coredns` on every install/upgrade to requests==limits (cpu 250m, memory 512Mi):
- **Guaranteed QoS** → kernel OOM killer no longer targets CoreDNS under node pressure.
- **512Mi** absorbs query-storm heap growth (170Mi default is a known-too-small upstream pain point).
- Idempotent and durable: k3s only re-applies its packaged coredns manifest when the k3s version changes, which happens exclusively through `leap server install/upgrade` — the same flow that re-runs this patch. Warn-only on failure so installs never break on it.

Validated with a server-side dry-run of the exact strategic-merge patch against a live k3d cluster.

## Testing
- `go build ./...`, `go vet`, `go test ./pkg/k3d/...` pass
- `kubectl patch --dry-run=server` of the identical patch JSON returns requests==limits as intended