### PR TITLE
Backport to 1.6.57 | Patch CoreDNS to Guaranteed QoS (512Mi) on install/upgrade

### DIFF
--- a/pkg/k3d/coredns.go
+++ b/pkg/k3d/coredns.go
@@ -1,0 +1,51 @@
+package k3d
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/tensorleap/helm-charts/pkg/log"
+)
+
+const (
+	corednsCpu    = "250m"
+	corednsMemory = "512Mi"
+)
+
+// PatchCoreDnsResources sets requests==limits on CoreDNS so it runs as Guaranteed QoS:
+// the k3s default (70Mi request / 170Mi limit, Burstable) both OOM-kills CoreDNS under
+// the engine's DNS query storms and makes it the kernel OOM killer's first victim under
+// node memory pressure (oom_score_adj ~999 vs -997 for Guaranteed). k3s only re-applies
+// its packaged coredns manifest when the k3s version changes, which happens exclusively
+// through install/upgrade — so re-patching here keeps the change durable.
+func PatchCoreDnsResources(ctx context.Context, kubeConfigPath, kubeContext string) error {
+	restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
+		&clientcmd.ConfigOverrides{CurrentContext: kubeContext},
+	).ClientConfig()
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig for coredns patch: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client for coredns patch: %w", err)
+	}
+
+	patch := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":"coredns","resources":{"requests":{"cpu":"%s","memory":"%s"},"limits":{"cpu":"%s","memory":"%s"}}}]}}}}`,
+		corednsCpu, corednsMemory, corednsCpu, corednsMemory)
+
+	_, err = clientset.AppsV1().Deployments("kube-system").Patch(
+		ctx, "coredns", types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch coredns resources: %w", err)
+	}
+
+	log.Infof("Patched coredns resources to Guaranteed QoS (cpu %s, memory %s)", corednsCpu, corednsMemory)
+	return nil
+}

--- a/pkg/server/install.go
+++ b/pkg/server/install.go
@@ -204,6 +204,10 @@ func InstallCharts(ctx context.Context, mnf *manifest.InstallationManifest, inst
 		defer monitor.Stop()
 	}
 
+	if err := k3d.PatchCoreDnsResources(ctx, kubeConfigPath, KUBE_CONTEXT); err != nil {
+		log.Warnf("Could not patch coredns resources: %v", err)
+	}
+
 	infraChartMeta := mnf.InfraHelmChart
 	isInfraReleaseExisted, err := helm.IsHelmReleaseExists(helmConfig, infraChartMeta.ReleaseName)
 	if err != nil {


### PR DESCRIPTION
Clean cherry-pick of 86eccd5f from master (PR #420) onto the 1.6.57 release branch for the patch release.

Fixes the CoreDNS outage that failed Sony's evaluate job `6a72dcab...` (BF-1135): the installer now patches `kube-system/coredns` to requests==limits (cpu 250m, memory 512Mi) on every install/upgrade — Guaranteed QoS so the kernel OOM killer no longer targets CoreDNS under node pressure, and 512Mi absorbs the engine's ndots-amplified DNS query storms that OOM-kill the k3s default 170Mi limit.

Verified on master branch code against a live k3d cluster: real code path patches, rollout completes, pod lands Guaranteed with exact resources, in-cluster DNS resolves, and re-running is a no-op (no pod churn on upgrades). `go build`/`vet`/`test ./pkg/k3d/...` pass on this branch after the pick.

See #420 for the full root-cause analysis.