### PR TITLE
Bump patch version and open version branches in the patch workflow

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -29,19 +29,24 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
         shell: bash
 
-      - name: Checkout RC branch
-        id: checkout_rc_branch
+      - name: Bump patch version and checkout patch branch
+        id: checkout_patch_branch
         run: |
           set -euo pipefail
-          # checkout-rc-branch prints the branch name on the first line and the
-          # is_new_branch flag on the second; take only the first line.
-          OUTPUT="$(make -s checkout-rc-branch)"
-          BRANCH="$(echo "$OUTPUT" | head -1)"
+          # checkout-patch-branch bumps the patch version (1.6.57* -> 1.6.58-rc.0) and prints
+          # the branch name on the first line, the is_new_branch flag on the second and the
+          # branch it was cut from on the third.
+          OUTPUT="$(make -s checkout-patch-branch)"
+          BRANCH="$(echo "$OUTPUT" | sed -n 1p)"
+          IS_NEW_BRANCH="$(echo "$OUTPUT" | sed -n 2p)"
+          BASE_BRANCH="$(echo "$OUTPUT" | sed -n 3p)"
           if [ -z "$BRANCH" ]; then
-            echo "Error: Failed to get branch name from checkout-rc-branch" >&2
+            echo "Error: Failed to get branch name from checkout-patch-branch" >&2
             exit 1
           fi
-          echo "rc_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "patch_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "is_new_branch=$IS_NEW_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Get new version
@@ -51,10 +56,43 @@ jobs:
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      # Cut the same version branch in engine/node-server/web-ui, off the branch this
+      # patch is based on (e.g. 1.6.58 from 1.6.57) so the patch carries the version
+      # branch state and not master. Idempotent - existing branches are left as is.
+      - name: Create external patch branches
+        run: |
+          make create-external-rc-branches
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.TENSORLEAP_OPS_GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ steps.checkout_patch_branch.outputs.patch_branch }}
+          BASE_BRANCH: ${{ steps.checkout_patch_branch.outputs.base_branch }}
+
+      - name: Notify Slack about new patch branches
+        if: steps.checkout_patch_branch.outputs.is_new_branch == 'true'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_TOKEN }}
+          errors: true
+          payload: |
+            channel: C0AAMFVFYM6
+            text: "🩹 New Patch Branch Created: ${{ steps.checkout_patch_branch.outputs.patch_branch }}"
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: "🩹 New Patch Branch Created: ${{ steps.checkout_patch_branch.outputs.patch_branch }}"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Patched from:* `${{ steps.checkout_patch_branch.outputs.base_branch }}`\n*Branch Links:*\n• <https://github.com/tensorleap/helm-charts/tree/${{ steps.checkout_patch_branch.outputs.patch_branch }}|helm-charts>\n• <https://github.com/tensorleap/engine/tree/${{ steps.checkout_patch_branch.outputs.patch_branch }}|engine>\n• <https://github.com/tensorleap/node-server/tree/${{ steps.checkout_patch_branch.outputs.patch_branch }}|node-server>\n• <https://github.com/tensorleap/web-ui/tree/${{ steps.checkout_patch_branch.outputs.patch_branch }}|web-ui>"
+
       - name: Update charts with branch images
         uses: ./.github/actions/update-images-from-branch
         with:
-          branch: ${{ steps.checkout_rc_branch.outputs.rc_branch }}
+          branch: ${{ steps.checkout_patch_branch.outputs.patch_branch }}
           github_token: ${{ secrets.TENSORLEAP_OPS_GITHUB_TOKEN }}
 
       - name: Set up Helm
@@ -88,21 +126,21 @@ jobs:
       - name: Commit version changes
         uses: EndBug/add-and-commit@v9
         with:
-          message: "Bump rc version to ${{ steps.get_version.outputs.version }} and update images.txt"
+          message: "Bump patch version to ${{ steps.get_version.outputs.version }} and update images.txt"
           github_token: ${{ secrets.TENSORLEAP_OPS_GITHUB_TOKEN }}
 
       - name: Release Charts
         uses: ./.github/actions/release-chart
         with:
           github_token: ${{ secrets.TENSORLEAP_OPS_GITHUB_TOKEN }}
-          branch: ${{ steps.checkout_rc_branch.outputs.rc_branch }}
+          branch: ${{ steps.checkout_patch_branch.outputs.patch_branch }}
 
       - name: Release Manifest
         uses: ./.github/actions/release-manifest
         with:
           github_token: ${{ secrets.TENSORLEAP_OPS_GITHUB_TOKEN }}
           custom_tag_prefix: ${{ inputs.custom_tag_prefix }}
-          branch: ${{ steps.checkout_rc_branch.outputs.rc_branch }}
+          branch: ${{ steps.checkout_patch_branch.outputs.patch_branch }}
 
   install-server:
     needs: patch

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: create-cluster drop-cluster helm-install helm-uninstall helm-reinstall helm-deps-up validate-k-env release-notes create-external-rc-branches
+.PHONY: create-cluster drop-cluster helm-install helm-uninstall helm-reinstall helm-deps-up validate-k-env release-notes create-external-rc-branches checkout-patch-branch
 
 SHELL := /bin/bash
 CLUSTER_NAME ?= tensorleap
@@ -172,8 +172,77 @@ checkout-rc-branch:
 	echo "$$BRANCH"
 	echo "$$IS_NEW_BRANCH"
 
+# Bump the patch version and checkout/create the matching version branch.
+# The patch component is bumped BEFORE the rc suffix, which is reset from the
+# existing tags of the new version (e.g. 1.6.57-rc.0 / 1.6.57-rc.1 / 1.6.57 -> 1.6.58-rc.0).
+# The new branch (e.g. 1.6.58) is cut from the branch the target runs on, so the
+# patch is built on top of the previous version branch and not on top of master.
+# Prints three lines for use in workflows: branch name, is_new_branch flag, base branch name.
+.PHONY: checkout-patch-branch
+.ONESHELL:
+checkout-patch-branch:
+	@set -euo pipefail
+	if [ ! -f charts/tensorleap/Chart.yaml ]; then
+	  echo "❌ charts/tensorleap/Chart.yaml not found" >&2
+	  exit 1
+	fi
+	VERSION_FULL="$$(awk '/^version:/{print $$2}' charts/tensorleap/Chart.yaml)"
+	if [ -z "$$VERSION_FULL" ]; then
+	  echo "❌ version not found in charts/tensorleap/Chart.yaml" >&2
+	  exit 1
+	fi
+	# Remove -rc.* suffix if present to get base version
+	VERSION="$$(echo "$$VERSION_FULL" | sed 's/-rc\.[0-9]*$$//')"
+	if ! echo "$$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$'; then
+	  echo "❌ unexpected version format in charts/tensorleap/Chart.yaml: $$VERSION_FULL" >&2
+	  exit 1
+	fi
+	MAJOR="$$(echo "$$VERSION" | cut -d. -f1)"
+	MINOR="$$(echo "$$VERSION" | cut -d. -f2)"
+	PATCH="$$(echo "$$VERSION" | cut -d. -f3)"
+	NEW_VERSION="$$MAJOR.$$MINOR.$$((PATCH+1))"
+	BASE_BRANCH="$$(git rev-parse --abbrev-ref HEAD)"
+	if [ "$$BASE_BRANCH" = "HEAD" ]; then
+	  echo "❌ detached HEAD - checkout the version branch to patch before running this target" >&2
+	  exit 1
+	fi
+	# Branch name is just the new base version (e.g., 1.6.58)
+	BRANCH="$$NEW_VERSION"
+	IS_NEW_BRANCH="false"
+	git fetch origin --prune >/dev/null 2>&1
+	# Check if we're already on the new version branch
+	if [ "$$BASE_BRANCH" != "$$BRANCH" ]; then
+	  # Checkout the version branch, or cut it from the branch we're currently on
+	  if git ls-remote --exit-code --heads origin "$$BRANCH" >/dev/null 2>&1; then
+	    git fetch origin "$$BRANCH" >/dev/null 2>&1
+	    git switch "$$BRANCH" >/dev/null 2>&1
+	  else
+	    git switch -c "$$BRANCH" >/dev/null 2>&1
+	    git push -u origin "$$BRANCH" >/dev/null 2>&1
+	    IS_NEW_BRANCH="true"
+	  fi
+	fi
+	# Find the next RC number by checking existing tags (fetch tags first)
+	git fetch origin --tags >/dev/null 2>&1
+	EXISTING_TAGS="$$(git tag -l "$${NEW_VERSION}-rc.*" 2>/dev/null | sed -nE "s/^$${NEW_VERSION}-rc\.([0-9]+)$$/\1/p")"
+	if [ -z "$$EXISTING_TAGS" ]; then
+	  NEXT=0
+	else
+	  MAX_RC="$$(printf "%s\n" "$$EXISTING_TAGS" | sort -n | tail -1)"
+	  NEXT=$$((MAX_RC+1))
+	fi
+	# Update Chart.yaml version to the bumped patch version plus RC suffix (matches tag)
+	VERSION_WITH_RC="$${NEW_VERSION}-rc.$${NEXT}"
+	sed -i.bak "s/^version: .*/version: $$VERSION_WITH_RC/" charts/tensorleap/Chart.yaml
+	rm -f charts/tensorleap/Chart.yaml.bak
+	# Output branch name, whether it's new, and the branch it was cut from (for use in workflows)
+	echo "$$BRANCH"
+	echo "$$IS_NEW_BRANCH"
+	echo "$$BASE_BRANCH"
+
 # Create version branches in external repositories (engine, node-server, web-ui)
 # Requires: GITHUB_TOKEN and BRANCH_NAME environment variables
+# Optional: BASE_BRANCH - branch to cut from in each repo (defaults to master)
 .PHONY: create-external-rc-branches
 .ONESHELL:
 create-external-rc-branches:
@@ -186,15 +255,16 @@ create-external-rc-branches:
 	  echo "❌ BRANCH_NAME environment variable is required" >&2
 	  exit 1
 	fi
+	BASE_BRANCH="$${BASE_BRANCH:-master}"
 	REPOS="tensorleap/engine tensorleap/node-server tensorleap/web-ui"
 	for REPO in $$REPOS; do
-	  echo "Creating branch $$BRANCH_NAME in $$REPO..."
-	  # Get the SHA of master branch
-	  MASTER_SHA=$$(curl -s -H "Authorization: token $$GITHUB_TOKEN" \
+	  echo "Creating branch $$BRANCH_NAME in $$REPO (from $$BASE_BRANCH)..."
+	  # Get the SHA of the base branch
+	  BASE_SHA=$$(curl -s -H "Authorization: token $$GITHUB_TOKEN" \
 	    -H "Accept: application/vnd.github.v3+json" \
-	    "https://api.github.com/repos/$$REPO/git/ref/heads/master" | jq -r '.object.sha')
-	  if [ "$$MASTER_SHA" = "null" ] || [ -z "$$MASTER_SHA" ]; then
-	    echo "❌ Failed to get master SHA for $$REPO" >&2
+	    "https://api.github.com/repos/$$REPO/git/ref/heads/$$BASE_BRANCH" | jq -r '.object.sha')
+	  if [ "$$BASE_SHA" = "null" ] || [ -z "$$BASE_SHA" ]; then
+	    echo "❌ Failed to get SHA of branch $$BASE_BRANCH for $$REPO" >&2
 	    exit 1
 	  fi
 	  # Create the branch
@@ -202,7 +272,7 @@ create-external-rc-branches:
 	    -H "Authorization: token $$GITHUB_TOKEN" \
 	    -H "Accept: application/vnd.github.v3+json" \
 	    "https://api.github.com/repos/$$REPO/git/refs" \
-	    -d "{\"ref\":\"refs/heads/$$BRANCH_NAME\",\"sha\":\"$$MASTER_SHA\"}")
+	    -d "{\"ref\":\"refs/heads/$$BRANCH_NAME\",\"sha\":\"$$BASE_SHA\"}")
 	  HTTP_CODE=$$(echo "$$RESPONSE" | tail -1)
 	  BODY=$$(echo "$$RESPONSE" | sed '$$d')
 	  if [ "$$HTTP_CODE" = "201" ]; then


### PR DESCRIPTION
## Problem

The Patch workflow reused `make checkout-rc-branch`, so a patch run only bumped the `-rc.N` suffix of the current version and never opened a new version branch.

## Behavior

`make checkout-patch-branch` bumps the patch component **before** the rc suffix and cuts the matching version branch in all four repos:

| Chart.yaml before | Workflow | After |
|---|---|---|
| `1.6.57-rc.0` | Release Candidate | `1.6.57-rc.1` (unchanged) |
| `1.6.57-rc.0` | Release Production | `1.6.57` (unchanged) |
| `1.6.57-rc.0` or `1.6.57-rc.1` | **Patch** | **`1.6.58-rc.0` + branch `1.6.58` in helm-charts, engine, node-server, web-ui** |

## Changes

**`Makefile`**
- New `checkout-patch-branch` target: strips any `-rc.N`, bumps the patch component, then re-derives the rc number from the *new* version's tags (so `rc.0` normally, and a re-run after a partial failure can't collide with an existing tag). Creates/pushes the version branch with the same create-or-switch mechanism as `checkout-rc-branch`, and prints branch / `is_new_branch` / base branch. Validates the version format and rejects a detached HEAD.
- `create-external-rc-branches` takes an optional `BASE_BRANCH` (defaults to `master`, so `release_candidate.yml` is unaffected).

**`.github/workflows/patch.yml`**
- `Checkout RC branch` → `Bump patch version and checkout patch branch`.
- New `Create external patch branches` step reusing `make create-external-rc-branches` — same mechanism as Release Candidate, including branch protection.
- New Slack notification mirroring the RC one (same channel, only when the branch is newly created).
- Commit message now reads "Bump patch version to …".

## Note on the branch base

The external branches are cut from the branch the patch runs on (`1.6.58` from `1.6.57`), **not** from `master`. RC cuts from master because an RC *is* master's snapshot; a patch has to carry the version-branch state. This is also what keeps `update-images-from-branch` correct — it resolves tags as `<branch>-<sha8>`, so the tag becomes `1.6.58-<1.6.57 tip sha>`, exactly what each service's CI builds when the new branch push lands.

Pre-existing in the RC flow too, and unchanged here: `install-server` may race the service CIs building those brand-new images, since the branches are created in the same run.

## Testing

Extracted the recipe with `make -n` and ran it against a throwaway repo with a fake remote: `1.6.57-rc.0` / `-rc.1` / `1.6.57` → `1.6.58-rc.0` with the branch cut at the `1.6.57` tip, `1.6.99 → 1.6.100` rollover, rc bump when a `1.6.58-rc.0` tag already exists, and both error guards. Note these targets need make 4.x for `.ONESHELL` (macOS ships 3.81; `ubuntu-latest` is fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)